### PR TITLE
feat(external-api): UI-Schreib-Paritaet — jede UI-Funktion via API (v0.45)

### DIFF
--- a/AUDIT_ui_parity_v0.45.md
+++ b/AUDIT_ui_parity_v0.45.md
@@ -1,0 +1,70 @@
+# Audit Report — v0.45 "UI-Paritaet" External Write API — 2026-06-23
+
+Scope: uncommitted working-tree diff only (external_v1.py +1701, external_v1_schemas.py +385,
+positions/private_equity/precious_metals/dividends `_core`-Refactors, Migration 085, neue Tests).
+Frameworks: OWASP Top 10 (A01 Broken Access Control, A04 Insecure Design), ASVS v4.0.3 L2, STRIDE
+(Tampering/Info-Disclosure/Repudiation), Multi-User-HEILIGE-Regel.
+
+## Zusammenfassung
+
+**PASS** — Security 0 kritisch / 0 hoch, QA ok, Architektur sauber. 2 Low + 1 Info.
+
+Die 7 abgefragten Risikobereiche wurden alle verifiziert und sind **korrekt umgesetzt**:
+
+1. Auth/Scope: alle 88 schreibenden Endpoints haben `require_scope(request, "write")` **und**
+   `Depends(get_api_user)` — automatisiert geprueft, 0 Treffer ohne beides.
+2. IDOR/user_id: jeder pfad-id-basierte Endpoint erzwingt Ownership (direkt via
+   `... .user_id != user.id → 404` oder via Service/`_core`, das `user.id` filtert). Kein Fund.
+3. PII: alle Write-Responses laufen durch `filter_*`-Whitelists; `filter_settings` strippt
+   `fred/fmp/finnhub_api_key` UND alle `*_api_key_masked`-Felder. Kein Klartext-/Ciphertext-Leak.
+4. Audit-Atomizitaet: ApiWriteLog wird in jeder Mutation **in derselben Transaktion** wie die
+   Mutation committet. Kein Two-Commit-Orphan auf einem Mutations-Pfad.
+5. Migration: alle 76 in `external_v1.py` verwendeten `action`-Strings sind in Migration 085
+   whitelisted (skript-verifiziert). Kein fehlender Wert → kein Prod-500-Risiko.
+6. Scope-Exclusions: keine Secret-Writes (API-Keys/SMTP/ntfy), keine Token-/Auth-/Admin-Endpoints.
+   `SettingsUpdate` hat keine Key-Felder; Key-Endpoints (`FredApiKeyUpdate` etc.) sind NICHT gespiegelt.
+7. `_core`-Refactors: Ownership, Encryption, sync-Calls (`sync_position`/`sync_metal_position`),
+   Commit-Reihenfolge und Return-Werte verhaltensidentisch zum Original. Kein Drift.
+
+## Findings
+
+| # | Bereich | Severity | Problem | Empfehlung |
+|---|---------|----------|---------|------------|
+| 1 | QA / Repudiation | Low | `import_parse`/`import_analyze`/`import_parse-with-mapping` (external_v1.py:5214, 5244, 5291) machen `db.add(log)` + `await db.commit()` **vor** dem `parse_csv`/`analyze_csv_structure`-Aufruf. Da Parse read-only ist, persistiert der Audit-Log auch dann, wenn der Parse danach mit 422 scheitert. Kein Orphan-**Mutation** (es gibt keine), aber der Log suggeriert eine erfolgreiche Aktion, die fehlschlug. | Akzeptabel als "Versuchs-Log". Optional: Log erst nach erfolgreichem Parse committen, oder Doku-Hinweis dass `import_parse` ein Attempt-Marker ist. |
+| 2 | Architektur / DoS | Low | `POST /screening/scan` (external_v1.py:4563) legt einen **global, nicht user-gescopten** `ScreeningScan` an (`models/screening.py:15` hat kein `user_id`). Ein Write-Token startet damit einen system-weiten Scan; der zurueckgegebene `scan_id` ist nicht user-isoliert (spiegelt aber 1:1 das interne Verhalten). | Kein IDOR auf User-Daten. Resourcen-Abuse durch das **harte `1/day`-Limit** ausreichend mitigiert. Belassen; ggf. dokumentieren dass Scans global sind. |
+| 3 | QA / Test-Abdeckung | Info | Test-DB baut via `create_all`, nicht Alembic → der `ck_api_write_log_action`-CHECK-Constraint ist in Tests **unsichtbar** (bekanntes Pattern, MEMORY). Ein in Code verwendeter, aber in Migration 085 fehlender `action` wuerde erst in Prod als 500 + Rollback auffallen. | Für v0.45 **nicht** kritisch: alle 76 Action-Strings sind skript-verifiziert in 085 vorhanden. Hinweis bleibt für künftige neue Actions. |
+
+## Verifizierte Stärken
+
+- **`_core`-Extraktion sauber**: Die internen Routen sind nun duenne Wrapper
+  (`return await create_position_core(db, user, data)`); `audit_log` wird als Keyword-only-Param
+  durchgereicht und in derselben Transaktion via `db.add(audit_log)` **vor** dem committenden
+  Aufruf persistiert. Encryption (`encrypt_field` auf serial/storage/notes/bank/iban),
+  `sync_metal_position`/`sync_position`-Aufrufe und `trigger_snapshot_regen` bleiben erhalten.
+- **Property-Endpoints ohne `_core`** rufen `property_service`-Funktionen, die self-committen, und
+  haengen den Log **davor** in die Session — atomar. `update/delete_mortgage|expense|income` nehmen
+  `uuid.UUID(int=0)` als (dokumentiert ungenutzten) `property_id` entgegen; die Ownership wird ueber
+  die aus dem Entity aufgeloeste `property_id` + `_verify_property_owner` erzwungen → **kein IDOR**.
+- **Settings-Doppelriegel**: `settings_to_dict` exponiert ohnehin nur `*_masked` + `has_*`; der
+  `filter_settings` entfernt zusaetzlich beide Schluessel-Varianten. Test `test_settings_never_exposes_secrets`.
+- **PII-Vertrag (v0.38) konsistent**: Owner-PII (bank_name/IBAN-maskiert/notes/serial/storage,
+  PE company_name/uid/register) wird wie im UI ausgeliefert, aber IBAN ist immer ueber
+  `decrypt_and_mask_iban` maskiert; Metal-`serial_number`/`storage_location` werden **dekryptiert**
+  (kein Ciphertext-Leak), nie roh.
+- **AsyncSession-Hygiene**: `import/confirm` regeneriert Snapshots in einer **eigenen**
+  `async_session()` (Background-Task) — entspricht der MEMORY-Regel "keine AsyncSession across
+  asyncio.gather/tasks teilen".
+- **Schema-Entkopplung**: alle `External*`-Write-Schemas sind `_StrictWrite` (extra=forbid),
+  bewusst von internen Schemas entkoppelt → interne Felderweiterungen leaken nicht automatisch.
+- **`fill_pending_order_external`**: `_do_fill` committet bewusst NICHT selbst
+  (caller-commit), der Fill-Log geht in denselben Commit — atomar verifiziert.
+- **`migration_rollback`/`backfill_bucket_snapshots`** nutzen `flush()` (kein self-commit) →
+  Log + Mutation im selben `db.commit()` des Endpoints.
+
+## Methodik
+
+- Migration-Cross-Check skript-basiert (alle `action="..."` + `_mk_re_log(...,"...")` gegen 085-Whitelist): 0 fehlend.
+- Scope-Check skript-basiert ueber alle 88 `@router.(post|put|patch|delete)`-Bloecke: 0 ohne `require_scope`+`get_api_user`.
+- Alle 4 `_core`-Refactors zeilenweise gegen das Original verglichen (Ownership/Encryption/Commit/Return).
+- Service-Ownership stichprobenartig im Quellcode verifiziert (`property_service`, `dividends`-core,
+  `settings_service` self-commit).

--- a/backend/alembic/versions/085_api_write_log_ui_parity_actions.py
+++ b/backend/alembic/versions/085_api_write_log_ui_parity_actions.py
@@ -1,0 +1,151 @@
+"""Erweitere api_write_log.action-Whitelist um alle UI-Paritaets-Aktionen (v0.45).
+
+Mit der vollen Schreib-Paritaet der externen API (api/external_v1.py) zum UI —
+Positionen, Immobilien, Private Equity, Edelmetalle, Dividenden, Buckets,
+Performance-Aktionen, Screening, ETF-Sektoren, EPS-Schwellen, Analyse,
+Settings/Onboarding und Import — braucht die ``action``-Spalte zahlreiche neue
+Werte.
+
+Wie 080/081: der Audit-Log wird atomar mit der Mutation committet — fehlt der
+Wert im CHECK-Constraint, rollt der gemeinsame Commit alles zurueck und der
+Endpoint ist unbenutzbar (Prod-500). Daher MUSS diese Migration vor dem Deploy
+laufen.
+
+Revision ID: 085
+Revises: 084
+Create Date: 2026-06-23
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "085"
+down_revision: Union[str, None] = "084"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Stand nach Migration 081 (transaction_update/_delete inklusive).
+_OLD_ACTIONS = (
+    "notes_replace",
+    "notes_append",
+    "notes_clear",
+    "alert_create",
+    "alert_update",
+    "alert_delete",
+    "watchlist_add",
+    "watchlist_remove",
+    "pending_order_create",
+    "pending_order_update",
+    "pending_order_cancel",
+    "pending_order_fill",
+    "stop_loss_update",
+    "stop_loss_batch",
+    "transaction_create",
+    "transaction_update",
+    "transaction_delete",
+)
+
+# Neue UI-Paritaets-Aktionen (v0.45).
+_NEW_PARITY_ACTIONS = (
+    # Positionen
+    "position_create",
+    "position_update",
+    "position_delete",
+    "position_recalculate",
+    # Immobilien
+    "property_create",
+    "property_update",
+    "property_delete",
+    "mortgage_create",
+    "mortgage_update",
+    "mortgage_delete",
+    "property_expense_create",
+    "property_expense_update",
+    "property_expense_delete",
+    "property_income_create",
+    "property_income_update",
+    "property_income_delete",
+    # Private Equity
+    "pe_holding_create",
+    "pe_holding_update",
+    "pe_holding_delete",
+    "pe_valuation_create",
+    "pe_valuation_update",
+    "pe_valuation_delete",
+    "pe_dividend_create",
+    "pe_dividend_update",
+    "pe_dividend_delete",
+    # Edelmetalle
+    "metal_item_create",
+    "metal_item_update",
+    "metal_item_delete",
+    "metal_expense_create",
+    "metal_expense_update",
+    "metal_expense_delete",
+    # Dividenden (Pending)
+    "dividend_confirm",
+    "dividend_dismiss",
+    # Performance-Aktionen
+    "performance_recalculate",
+    "performance_fix_total_chf",
+    "performance_regen_snapshots",
+    "performance_earnings_refresh",
+    # Screening
+    "screening_scan",
+    # ETF-Sektoren
+    "etf_sector_update",
+    "etf_sector_delete",
+    # EPS-Scanner
+    "eps_thresholds_update",
+    # Analyse
+    "resistance_update",
+    "watchlist_tag_add",
+    "watchlist_tag_remove",
+    # Settings / Onboarding
+    "settings_update",
+    "alert_pref_update",
+    "onboarding_update",
+    # Buckets
+    "bucket_create",
+    "bucket_update",
+    "bucket_delete",
+    "bucket_from_template",
+    "bucket_migration_rollback",
+    "bucket_split_position",
+    "bucket_move_position",
+    "bucket_import_rule_create",
+    "bucket_import_rule_del",
+    "bucket_backfill_snapshots",
+    "bucket_onboarding_dismiss",
+    # Import
+    "import_parse",
+    "import_confirm",
+    "import_profile_create",
+    "import_profile_delete",
+)
+
+_NEW_ACTIONS = _OLD_ACTIONS + _NEW_PARITY_ACTIONS
+
+
+def _check_clause(actions: tuple[str, ...]) -> str:
+    return "action IN (" + ",".join(f"'{a}'" for a in actions) + ")"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("api_write_log") as batch:
+        batch.drop_constraint("ck_api_write_log_action", type_="check")
+        batch.create_check_constraint(
+            "ck_api_write_log_action",
+            _check_clause(_NEW_ACTIONS),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("api_write_log") as batch:
+        batch.drop_constraint("ck_api_write_log_action", type_="check")
+        batch.create_check_constraint(
+            "ck_api_write_log_action",
+            _check_clause(_OLD_ACTIONS),
+        )

--- a/backend/api/dividends.py
+++ b/backend/api/dividends.py
@@ -28,6 +28,7 @@ from api.auth import limiter
 from api.portfolio import invalidate_portfolio_cache
 from auth import get_current_user
 from db import get_db
+from models.api_write_log import ApiWriteLog
 from models.pending_dividend import (
     PendingDividend,
     STATUS_CONFIRMED,
@@ -215,18 +216,21 @@ async def count_pending_dividends(
     return DividendCountResponse(pending_count=int(count or 0))
 
 
-@router.post("/{pending_id}/confirm", status_code=201)
-@limiter.limit("30/minute")
-async def confirm_pending_dividend(
-    request: Request,
+async def confirm_pending_dividend_core(
+    db: AsyncSession,
+    user: User,
     pending_id: uuid.UUID,
     data: ConfirmDividendRequest,
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user),
-):
-    """Lege eine `dividend`-Transaktion an und markiere den Pending-Eintrag
-    als ``confirmed``. Persistiert Sticky-Withholding bei Abweichung vom
-    aufgeloesten Default-Wert (R1).
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Bestaetigen einer Pending-Dividende — geteilt zwischen
+    internem UI-Endpoint und externer API. Legt eine ``dividend``-Transaktion an
+    und markiert den Pending-Eintrag als ``confirmed``. Persistiert
+    Sticky-Withholding bei Abweichung vom aufgeloesten Default-Wert (R1).
+
+    Bei gesetztem ``audit_log`` wird dieser atomar mit der Transaktion
+    committet (target_id = Transaktions-ID, ticker = Position-Ticker).
     """
     pending = await db.get(PendingDividend, pending_id)
     if not pending or pending.user_id != user.id:
@@ -284,6 +288,12 @@ async def confirm_pending_dividend(
     pending.matched_transaction_id = txn.id
     pending.updated_at = datetime.utcnow()
 
+    # Audit-Log atomar mit der Transaktion committen (gleiche DB-Transaktion).
+    if audit_log is not None:
+        audit_log.target_id = txn.id
+        audit_log.ticker = (position.ticker or "")[:30]
+        db.add(audit_log)
+
     await db.commit()
     await db.refresh(txn)
 
@@ -297,17 +307,35 @@ async def confirm_pending_dividend(
     }
 
 
-@router.post("/{pending_id}/dismiss")
+@router.post("/{pending_id}/confirm", status_code=201)
 @limiter.limit("30/minute")
-async def dismiss_pending_dividend(
+async def confirm_pending_dividend(
     request: Request,
     pending_id: uuid.UUID,
-    data: DismissDividendRequest,
+    data: ConfirmDividendRequest,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
-    """Pending-Eintrag dauerhaft als ignoriert markieren. Reason optional,
-    plain TEXT (R9, max 500 Zeichen).
+    """Lege eine `dividend`-Transaktion an und markiere den Pending-Eintrag
+    als ``confirmed``. Delegiert an ``confirm_pending_dividend_core``.
+    """
+    return await confirm_pending_dividend_core(db, user, pending_id, data)
+
+
+async def dismiss_pending_dividend_core(
+    db: AsyncSession,
+    user: User,
+    pending_id: uuid.UUID,
+    data: DismissDividendRequest,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Verwerfen einer Pending-Dividende — geteilt zwischen
+    internem UI-Endpoint und externer API. Markiert den Eintrag dauerhaft als
+    ignoriert. Reason optional, plain TEXT (R9, max 500 Zeichen).
+
+    Bei gesetztem ``audit_log`` wird dieser atomar committet
+    (target_id = Pending-ID).
     """
     pending = await db.get(PendingDividend, pending_id)
     if not pending or pending.user_id != user.id:
@@ -320,6 +348,27 @@ async def dismiss_pending_dividend(
         # max_length wird bereits von Pydantic erzwungen; defensiv truncate.
         pending.notes = data.reason[:500]
     pending.updated_at = datetime.utcnow()
+
+    # Audit-Log atomar mit dem Status-Update committen (gleiche DB-Transaktion).
+    if audit_log is not None:
+        audit_log.target_id = pending.id
+        db.add(audit_log)
+
     await db.commit()
 
     return {"id": str(pending.id), "status": pending.status}
+
+
+@router.post("/{pending_id}/dismiss")
+@limiter.limit("30/minute")
+async def dismiss_pending_dividend(
+    request: Request,
+    pending_id: uuid.UUID,
+    data: DismissDividendRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Pending-Eintrag dauerhaft als ignoriert markieren. Delegiert an
+    ``dismiss_pending_dividend_core``.
+    """
+    return await dismiss_pending_dividend_core(db, user, pending_id, data)

--- a/backend/api/external_v1.py
+++ b/backend/api/external_v1.py
@@ -21,7 +21,7 @@ import hashlib
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import Response
 from sqlalchemy import delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,11 +31,38 @@ from api.external_v1_schemas import (
     ExternalAlertCreate,
     ExternalAlertUpdate,
     ExternalNotesUpdate,
+    ExternalDividendConfirm,
+    ExternalDividendDismiss,
+    ExternalEpsThresholds,
+    ExternalEtfSectorWeights,
+    ExternalMetalCreate,
+    ExternalMetalExpenseCreate,
+    ExternalMetalExpenseUpdate,
+    ExternalMetalUpdate,
+    ExternalMortgageCreate,
+    ExternalMortgageUpdate,
+    ExternalPEDividendCreate,
+    ExternalPEDividendUpdate,
+    ExternalPEHoldingCreate,
+    ExternalPEHoldingUpdate,
+    ExternalPEValuationCreate,
+    ExternalPEValuationUpdate,
     ExternalPendingOrderCreate,
     ExternalPendingOrderFill,
     ExternalPendingOrderUpdate,
+    ExternalOnboardingStep,
+    ExternalPositionCreate,
+    ExternalPositionUpdate,
+    ExternalPropertyCreate,
+    ExternalPropertyExpenseCreate,
+    ExternalPropertyExpenseUpdate,
+    ExternalPropertyIncomeCreate,
+    ExternalPropertyIncomeUpdate,
+    ExternalPropertyUpdate,
+    ExternalResistanceUpdate,
     ExternalStopLossBatchRequest,
     ExternalStopLossUpdate,
+    ExternalTagCreate,
     ExternalTransactionCreate,
     ExternalTransactionUpdate,
     ExternalWatchlistAdd,
@@ -44,9 +71,16 @@ from api.external_v1_schemas import (
     ReportPrune,
     ReportUpload,
     STOP_LOSS_BATCH_MAX_ITEMS,
+    filter_bucket,
+    filter_mortgage,
+    filter_metal_expense,
+    filter_metal_item,
+    filter_pe_holding,
     filter_pension_position,
     filter_position,
     filter_property,
+    filter_property_expense,
+    filter_property_income,
     filter_settings,
 )
 from constants.limits import (
@@ -2461,6 +2495,379 @@ async def batch_stop_loss_external(
     return result
 
 
+# --- Positionen (Write) — volle Paritaet zum internen UI ---
+
+
+@router.post("/positions", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def create_position_external(
+    request: Request,
+    data: ExternalPositionCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Position anlegen — Paritaet zum UI. Erfordert Scope ``write``.
+
+    Teilt die Kernlogik (Bucket-Auto-Zuordnung, PII-Verschluesselung,
+    Sektor-Ableitung, Snapshot-Regen) mit dem internen Endpoint ueber
+    ``api.positions.create_position_core``. Der ``ApiWriteLog`` wird atomar mit
+    der Position committet."""
+    require_scope(request, "write")
+
+    from api.positions import PositionCreate, create_position_core
+
+    internal_data = PositionCreate(**data.model_dump(exclude_unset=True))
+    token = getattr(request.state, "api_token", None)
+    audit_log = ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker="",
+        action="position_create",
+    )
+    result = await create_position_core(db, user, internal_data, audit_log=audit_log)
+    return filter_position(result)
+
+
+@router.put("/positions/by-id/{position_id}")
+@limiter.limit(RATE_LIMIT)
+async def update_position_external(
+    request: Request,
+    position_id: uuid.UUID,
+    data: ExternalPositionUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Position aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+
+    from api.positions import PositionUpdate, update_position_core
+
+    internal_data = PositionUpdate(**data.model_dump(exclude_unset=True))
+    token = getattr(request.state, "api_token", None)
+    audit_log = ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker="",
+        action="position_update",
+    )
+    result = await update_position_core(db, user, position_id, internal_data, audit_log=audit_log)
+    return filter_position(result)
+
+
+@router.delete("/positions/by-id/{position_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def delete_position_external(
+    request: Request,
+    position_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Position loeschen — Paritaet zum UI. Erfordert Scope ``write``.
+
+    Macht die Snapshot-Regen-Wirkung an. Der ``ApiWriteLog`` wird atomar mit dem
+    Delete committet."""
+    require_scope(request, "write")
+
+    from api.positions import delete_position_core
+
+    token = getattr(request.state, "api_token", None)
+    audit_log = ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker="",
+        action="position_delete",
+    )
+    await delete_position_core(db, user, position_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+@router.post("/positions/recalculate")
+@limiter.limit(RATE_LIMIT)
+async def recalculate_positions_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Alle Positionen neu berechnen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+
+    from services.recalculate_service import recalculate_all_positions
+
+    token = getattr(request.state, "api_token", None)
+    db.add(ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker="",
+        action="position_recalculate",
+    ))
+    results = await recalculate_all_positions(db, user_id=user.id)
+    await db.commit()
+    return {"results": results}
+
+
+@router.post("/positions/by-id/{position_id}/recalculate")
+@limiter.limit(RATE_LIMIT)
+async def recalculate_position_external(
+    request: Request,
+    position_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Einzelne Position neu berechnen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+
+    from api.portfolio import invalidate_portfolio_cache
+    from models.position import Position as _Position
+    from services.recalculate_service import recalculate_position
+
+    pos = await db.get(_Position, position_id)
+    if not pos or pos.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Position nicht gefunden")
+    token = getattr(request.state, "api_token", None)
+    db.add(ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker=(pos.ticker or "")[:30],
+        action="position_recalculate",
+        target_id=pos.id,
+    ))
+    result = await recalculate_position(db, position_id)
+    await db.commit()
+    invalidate_portfolio_cache(str(user.id))
+    return result
+
+
+# --- Immobilien (Write) — volle Paritaet zum internen UI ---
+#
+# Die internen Routen (api/real_estate.py) sind duenne Wrapper ueber
+# ``services.property_service`` (self-committing). Die externen Endpoints rufen
+# dieselben Service-Funktionen und haengen einen ``ApiWriteLog`` an, der mit dem
+# Service-Commit atomar persistiert wird (Log VOR dem Service-Aufruf in die
+# Session, target_id bei Updates/Deletes vom Pfad-Parameter).
+
+
+def _mk_re_log(request: Request, user: User, action: str, target_id=None) -> ApiWriteLog:
+    token = getattr(request.state, "api_token", None)
+    return ApiWriteLog(
+        token_id=getattr(token, "id", None),
+        user_id=user.id,
+        ticker="",
+        action=action,
+        target_id=target_id,
+    )
+
+
+@router.post("/immobilien", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def create_property_external(
+    request: Request,
+    data: ExternalPropertyCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilie anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import create_property as svc
+
+    db.add(_mk_re_log(request, user, "property_create"))
+    result = await svc(db, user.id, data.model_dump())
+    return filter_property(result)
+
+
+@router.put("/immobilien/{property_id}")
+@limiter.limit(RATE_LIMIT)
+async def update_property_external(
+    request: Request,
+    property_id: uuid.UUID,
+    data: ExternalPropertyUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilie aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import update_property as svc
+
+    db.add(_mk_re_log(request, user, "property_update", target_id=property_id))
+    result = await svc(db, user.id, property_id, data.model_dump(exclude_unset=True))
+    return filter_property(result)
+
+
+@router.delete("/immobilien/{property_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def delete_property_external(
+    request: Request,
+    property_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Immobilie loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import delete_property as svc
+
+    db.add(_mk_re_log(request, user, "property_delete", target_id=property_id))
+    await svc(db, user.id, property_id)
+    return Response(status_code=204)
+
+
+@router.post("/immobilien/{property_id}/hypotheken", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def create_mortgage_external(
+    request: Request,
+    property_id: uuid.UUID,
+    data: ExternalMortgageCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Hypothek anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import create_mortgage as svc
+
+    db.add(_mk_re_log(request, user, "mortgage_create", target_id=property_id))
+    result = await svc(db, user.id, property_id, data.model_dump())
+    return filter_mortgage(result)
+
+
+@router.put("/immobilien/hypotheken/{mortgage_id}")
+@limiter.limit(RATE_LIMIT)
+async def update_mortgage_external(
+    request: Request,
+    mortgage_id: uuid.UUID,
+    data: ExternalMortgageUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Hypothek aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import update_mortgage as svc
+
+    db.add(_mk_re_log(request, user, "mortgage_update", target_id=mortgage_id))
+    result = await svc(db, user.id, uuid.UUID(int=0), mortgage_id, data.model_dump(exclude_unset=True))
+    return filter_mortgage(result)
+
+
+@router.delete("/immobilien/hypotheken/{mortgage_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def delete_mortgage_external(
+    request: Request,
+    mortgage_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Hypothek loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import delete_mortgage as svc
+
+    db.add(_mk_re_log(request, user, "mortgage_delete", target_id=mortgage_id))
+    await svc(db, user.id, uuid.UUID(int=0), mortgage_id)
+    return Response(status_code=204)
+
+
+@router.post("/immobilien/{property_id}/ausgaben", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def create_property_expense_external(
+    request: Request,
+    property_id: uuid.UUID,
+    data: ExternalPropertyExpenseCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilien-Ausgabe anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import create_expense as svc
+
+    db.add(_mk_re_log(request, user, "property_expense_create", target_id=property_id))
+    result = await svc(db, user.id, property_id, data.model_dump())
+    return filter_property_expense(result)
+
+
+@router.put("/immobilien/ausgaben/{expense_id}")
+@limiter.limit(RATE_LIMIT)
+async def update_property_expense_external(
+    request: Request,
+    expense_id: uuid.UUID,
+    data: ExternalPropertyExpenseUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilien-Ausgabe aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import update_expense as svc
+
+    db.add(_mk_re_log(request, user, "property_expense_update", target_id=expense_id))
+    result = await svc(db, user.id, uuid.UUID(int=0), expense_id, data.model_dump(exclude_unset=True))
+    return filter_property_expense(result)
+
+
+@router.delete("/immobilien/ausgaben/{expense_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def delete_property_expense_external(
+    request: Request,
+    expense_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Immobilien-Ausgabe loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import delete_expense as svc
+
+    db.add(_mk_re_log(request, user, "property_expense_delete", target_id=expense_id))
+    await svc(db, user.id, uuid.UUID(int=0), expense_id)
+    return Response(status_code=204)
+
+
+@router.post("/immobilien/{property_id}/einnahmen", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def create_property_income_external(
+    request: Request,
+    property_id: uuid.UUID,
+    data: ExternalPropertyIncomeCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilien-Einnahme anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import create_income as svc
+
+    db.add(_mk_re_log(request, user, "property_income_create", target_id=property_id))
+    result = await svc(db, user.id, property_id, data.model_dump())
+    return filter_property_income(result)
+
+
+@router.put("/immobilien/einnahmen/{income_id}")
+@limiter.limit(RATE_LIMIT)
+async def update_property_income_external(
+    request: Request,
+    income_id: uuid.UUID,
+    data: ExternalPropertyIncomeUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Immobilien-Einnahme aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import update_income as svc
+
+    db.add(_mk_re_log(request, user, "property_income_update", target_id=income_id))
+    result = await svc(db, user.id, uuid.UUID(int=0), income_id, data.model_dump(exclude_unset=True))
+    return filter_property_income(result)
+
+
+@router.delete("/immobilien/einnahmen/{income_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def delete_property_income_external(
+    request: Request,
+    income_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Immobilien-Einnahme loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from services.property_service import delete_income as svc
+
+    db.add(_mk_re_log(request, user, "property_income_delete", target_id=income_id))
+    await svc(db, user.id, uuid.UUID(int=0), income_id)
+    return Response(status_code=204)
+
+
 # --- Transactions (Read + Write) ---
 
 
@@ -3719,3 +4126,1300 @@ async def taxonomy_sectors_external(
         "multi_sector_industries": MULTI_SECTOR_INDUSTRIES,
         "sectors_with_industries": SECTORS_WITH_INDUSTRIES,
     }
+
+
+# =====================================================================
+# UI-Paritaet v0.45 — restliche Schreib-Endpoints (Scope ``write``)
+# Jeder Endpoint spiegelt 1:1 das interne UI ueber dieselbe Kernlogik
+# (geteilte ``_core``-Funktionen bzw. Service-Layer) und haengt einen
+# atomaren ``ApiWriteLog`` an.
+# =====================================================================
+
+
+# --- Private Equity (Write) ---
+
+
+@router.post("/private-equity", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def pe_create_holding_external(
+    request: Request,
+    data: ExternalPEHoldingCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Beteiligung anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import HoldingCreate, create_holding_core
+
+    audit_log = _mk_re_log(request, user, "pe_holding_create")
+    result = await create_holding_core(
+        db, user, HoldingCreate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.put("/private-equity/{holding_id}")
+@limiter.limit(RATE_LIMIT)
+async def pe_update_holding_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    data: ExternalPEHoldingUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Beteiligung aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import HoldingUpdate, update_holding_core
+
+    audit_log = _mk_re_log(request, user, "pe_holding_update", target_id=holding_id)
+    result = await update_holding_core(
+        db, user, holding_id, HoldingUpdate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.delete("/private-equity/{holding_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def pe_delete_holding_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """PE-Beteiligung loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import delete_holding_core
+
+    audit_log = _mk_re_log(request, user, "pe_holding_delete", target_id=holding_id)
+    await delete_holding_core(db, user, holding_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+@router.post("/private-equity/{holding_id}/valuations", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def pe_create_valuation_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    data: ExternalPEValuationCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Bewertung anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import ValuationCreate, create_valuation_core
+
+    audit_log = _mk_re_log(request, user, "pe_valuation_create", target_id=holding_id)
+    result = await create_valuation_core(
+        db, user, holding_id, ValuationCreate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.put("/private-equity/{holding_id}/valuations/{valuation_id}")
+@limiter.limit(RATE_LIMIT)
+async def pe_update_valuation_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    valuation_id: uuid.UUID,
+    data: ExternalPEValuationUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Bewertung aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import ValuationUpdate, update_valuation_core
+
+    audit_log = _mk_re_log(request, user, "pe_valuation_update", target_id=holding_id)
+    result = await update_valuation_core(
+        db, user, holding_id, valuation_id, ValuationUpdate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.delete("/private-equity/{holding_id}/valuations/{valuation_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def pe_delete_valuation_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    valuation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """PE-Bewertung loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import delete_valuation_core
+
+    audit_log = _mk_re_log(request, user, "pe_valuation_delete", target_id=holding_id)
+    await delete_valuation_core(db, user, holding_id, valuation_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+@router.post("/private-equity/{holding_id}/dividends", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def pe_create_dividend_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    data: ExternalPEDividendCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Dividende anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import DividendCreate, create_dividend_core
+
+    audit_log = _mk_re_log(request, user, "pe_dividend_create", target_id=holding_id)
+    result = await create_dividend_core(
+        db, user, holding_id, DividendCreate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.put("/private-equity/{holding_id}/dividends/{dividend_id}")
+@limiter.limit(RATE_LIMIT)
+async def pe_update_dividend_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    dividend_id: uuid.UUID,
+    data: ExternalPEDividendUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """PE-Dividende aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import DividendUpdate, update_dividend_core
+
+    audit_log = _mk_re_log(request, user, "pe_dividend_update", target_id=holding_id)
+    result = await update_dividend_core(
+        db, user, holding_id, dividend_id, DividendUpdate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_pe_holding(result)
+
+
+@router.delete("/private-equity/{holding_id}/dividends/{dividend_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def pe_delete_dividend_external(
+    request: Request,
+    holding_id: uuid.UUID,
+    dividend_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """PE-Dividende loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.private_equity import delete_dividend_core
+
+    audit_log = _mk_re_log(request, user, "pe_dividend_delete", target_id=holding_id)
+    await delete_dividend_core(db, user, holding_id, dividend_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+# --- Edelmetalle (Write) ---
+
+
+@router.post("/precious-metals", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def metal_create_item_external(
+    request: Request,
+    data: ExternalMetalCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Edelmetall-Bestand anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import PreciousMetalCreate, create_metal_item_core
+
+    audit_log = _mk_re_log(request, user, "metal_item_create")
+    result = await create_metal_item_core(
+        db, user, PreciousMetalCreate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_metal_item(result)
+
+
+@router.put("/precious-metals/{item_id}")
+@limiter.limit(RATE_LIMIT)
+async def metal_update_item_external(
+    request: Request,
+    item_id: uuid.UUID,
+    data: ExternalMetalUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Edelmetall-Bestand aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import PreciousMetalUpdate, update_metal_item_core
+
+    audit_log = _mk_re_log(request, user, "metal_item_update", target_id=item_id)
+    result = await update_metal_item_core(
+        db, user, item_id, PreciousMetalUpdate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_metal_item(result)
+
+
+@router.delete("/precious-metals/{item_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def metal_delete_item_external(
+    request: Request,
+    item_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Edelmetall-Bestand loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import delete_metal_item_core
+
+    audit_log = _mk_re_log(request, user, "metal_item_delete", target_id=item_id)
+    await delete_metal_item_core(db, user, item_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+@router.post("/precious-metals/expenses", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def metal_create_expense_external(
+    request: Request,
+    data: ExternalMetalExpenseCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Edelmetall-Ausgabe anlegen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import ExpenseCreate as MetalExpenseCreate, create_metal_expense_core
+
+    audit_log = _mk_re_log(request, user, "metal_expense_create")
+    result = await create_metal_expense_core(
+        db, user, MetalExpenseCreate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_metal_expense(result)
+
+
+@router.put("/precious-metals/expenses/{expense_id}")
+@limiter.limit(RATE_LIMIT)
+async def metal_update_expense_external(
+    request: Request,
+    expense_id: uuid.UUID,
+    data: ExternalMetalExpenseUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Edelmetall-Ausgabe aendern — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import ExpenseUpdate as MetalExpenseUpdate, update_metal_expense_core
+
+    audit_log = _mk_re_log(request, user, "metal_expense_update", target_id=expense_id)
+    result = await update_metal_expense_core(
+        db, user, expense_id, MetalExpenseUpdate(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+    return filter_metal_expense(result)
+
+
+@router.delete("/precious-metals/expenses/{expense_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def metal_delete_expense_external(
+    request: Request,
+    expense_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Edelmetall-Ausgabe loeschen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.precious_metals import delete_metal_expense_core
+
+    audit_log = _mk_re_log(request, user, "metal_expense_delete", target_id=expense_id)
+    await delete_metal_expense_core(db, user, expense_id, audit_log=audit_log)
+    return Response(status_code=204)
+
+
+# --- Dividenden (Write) — Pending confirm/dismiss ---
+
+
+@router.post("/dividends/{pending_id}/confirm", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def dividend_confirm_external(
+    request: Request,
+    pending_id: uuid.UUID,
+    data: ExternalDividendConfirm,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Pending-Dividende bestaetigen (bucht Dividenden-Transaktion) — Paritaet
+    zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.dividends import ConfirmDividendRequest, confirm_pending_dividend_core
+
+    audit_log = _mk_re_log(request, user, "dividend_confirm", target_id=pending_id)
+    return await confirm_pending_dividend_core(
+        db, user, pending_id, ConfirmDividendRequest(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+
+
+@router.post("/dividends/{pending_id}/dismiss")
+@limiter.limit(RATE_LIMIT)
+async def dividend_dismiss_external(
+    request: Request,
+    pending_id: uuid.UUID,
+    data: ExternalDividendDismiss,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Pending-Dividende verwerfen — Paritaet zum UI. Erfordert Scope ``write``."""
+    require_scope(request, "write")
+    from api.dividends import DismissDividendRequest, dismiss_pending_dividend_core
+
+    audit_log = _mk_re_log(request, user, "dividend_dismiss", target_id=pending_id)
+    return await dismiss_pending_dividend_core(
+        db, user, pending_id, DismissDividendRequest(**data.model_dump(exclude_unset=True)), audit_log=audit_log,
+    )
+
+
+# --- Performance-Aktionen (Write) ---
+
+
+@router.post("/performance/recalculate")
+@limiter.limit(RATE_LIMIT)
+async def performance_recalculate_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Cost-Basis aller Positionen aus Transaktionen neu rechnen + Snapshot-Regen
+    — Paritaet zum UI (POST /api/performance/recalculate). Scope ``write``."""
+    require_scope(request, "write")
+    from datetime import date as _date
+    from services.recalculate_service import recalculate_all_positions
+    from services.snapshot_trigger import trigger_snapshot_regen
+
+    db.add(_mk_re_log(request, user, "performance_recalculate"))
+    results = await recalculate_all_positions(db, user_id=user.id)
+    positions = [
+        {
+            "ticker": r["ticker"],
+            "old_cost_basis_chf": r["old_cost_basis_chf"],
+            "new_cost_basis_chf": r["new_cost_basis_chf"],
+            "delta_chf": round(r["new_cost_basis_chf"] - r["old_cost_basis_chf"], 2),
+        }
+        for r in results
+        if "error" not in r
+    ]
+    trigger_snapshot_regen(user.id, _date(2000, 1, 1))
+    return {"recalculated": len(positions), "positions": positions, "snapshots_regenerating": True}
+
+
+@router.post("/performance/fix-total-chf")
+@limiter.limit(RATE_LIMIT)
+async def performance_fix_total_chf_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """total_chf aus fx_rate_to_chf fuer Fremdwaehrungs-Transaktionen korrigieren
+    — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.transaction_service import fix_foreign_total_chf
+
+    db.add(_mk_re_log(request, user, "performance_fix_total_chf"))
+    result = await fix_foreign_total_chf(db, user.id)
+    await db.commit()
+    return result
+
+
+@router.post("/performance/regenerate-snapshots")
+@limiter.limit(RATE_LIMIT)
+async def performance_regenerate_snapshots_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Alle Portfolio-Snapshots aus Ledger + Historie neu bauen — Paritaet zum
+    UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.snapshot_service import regenerate_snapshots
+
+    db.add(_mk_re_log(request, user, "performance_regen_snapshots"))
+    result = await regenerate_snapshots(db, user.id)
+    await db.commit()
+    return result
+
+
+@router.post("/performance/earnings/refresh")
+@limiter.limit(RATE_LIMIT)
+async def performance_earnings_refresh_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Naechste Earnings-Termine aller aktiven Stock/ETF-Positionen aktualisieren
+    — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.earnings_service import refresh_all_earnings
+
+    db.add(_mk_re_log(request, user, "performance_earnings_refresh"))
+    result = await refresh_all_earnings(db, user.id)
+    await db.commit()
+    return result
+
+
+# --- Screening-Scan (Write) ---
+
+
+@router.post("/screening/scan", status_code=201)
+@limiter.limit("1/day")
+async def screening_scan_external(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Neuen Screening-Scan starten (Fortschritt via GET /screening/scan/{id}/
+    progress) — Paritaet zum UI. Scope ``write``. Hartes 1/Tag-Limit wie intern."""
+    require_scope(request, "write")
+    from api.screening import _run_scan_background
+
+    scan = ScreeningScan(status="pending", steps=[])
+    db.add(scan)
+    db.add(_mk_re_log(request, user, "screening_scan"))
+    await db.commit()
+    await db.refresh(scan)
+    background_tasks.add_task(_run_scan_background, scan.id)
+    return {"scan_id": str(scan.id), "status": "pending"}
+
+
+# --- ETF-Sektor-Gewichte (Write) ---
+
+
+@router.put("/etf-sectors/{ticker}")
+@limiter.limit(RATE_LIMIT)
+async def etf_sectors_put_external(
+    request: Request,
+    ticker: str,
+    body: ExternalEtfSectorWeights,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """ETF-Sektorgewichte setzen (ersetzt bestehende) — Paritaet zum UI.
+    Summe muss 100% (+/-0.1) ergeben. Scope ``write``."""
+    require_scope(request, "write")
+    from sqlalchemy import delete as _delete
+    from models.etf_sector_weight import EtfSectorWeight
+    from services.sector_mapping import FINVIZ_SECTORS
+
+    valid = set(FINVIZ_SECTORS)
+    for s in body.sectors:
+        if s.sector not in valid:
+            raise HTTPException(400, f"Ungueltiger Sektor: {s.sector}")
+        if not (0.0 <= s.weight_pct <= 100.0):
+            raise HTTPException(400, f"Gewichtung muss zwischen 0 und 100 liegen: {s.sector}")
+    total = sum(s.weight_pct for s in body.sectors)
+    if not (99.9 <= total <= 100.1):
+        raise HTTPException(400, f"Summe muss 100% ergeben (aktuell: {total:.1f}%)")
+
+    tkr = ticker.upper()
+    await db.execute(_delete(EtfSectorWeight).where(
+        EtfSectorWeight.ticker == tkr, EtfSectorWeight.user_id == user.id,
+    ))
+    for s in body.sectors:
+        if s.weight_pct > 0:
+            db.add(EtfSectorWeight(user_id=user.id, ticker=tkr, sector=s.sector, weight_pct=s.weight_pct))
+    db.add(_mk_re_log(request, user, "etf_sector_update"))
+    await db.commit()
+    return {"ticker": tkr, "sectors": [{"sector": s.sector, "weight_pct": s.weight_pct} for s in sorted(body.sectors, key=lambda x: x.weight_pct, reverse=True)]}
+
+
+@router.delete("/etf-sectors/{ticker}")
+@limiter.limit(RATE_LIMIT)
+async def etf_sectors_delete_external(
+    request: Request,
+    ticker: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """ETF-Sektorgewichte loeschen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from sqlalchemy import delete as _delete
+    from models.etf_sector_weight import EtfSectorWeight
+
+    await db.execute(_delete(EtfSectorWeight).where(
+        EtfSectorWeight.ticker == ticker.upper(), EtfSectorWeight.user_id == user.id,
+    ))
+    db.add(_mk_re_log(request, user, "etf_sector_delete"))
+    await db.commit()
+    return {"status": "deleted", "ticker": ticker.upper()}
+
+
+# --- EPS-Scanner-Schwellen (Write) ---
+
+
+@router.patch("/eps-scanner/thresholds")
+@limiter.limit(RATE_LIMIT)
+async def eps_thresholds_patch_external(
+    request: Request,
+    data: ExternalEpsThresholds,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """EPS-Scanner-Filterschwellen setzen (user-scoped) — Paritaet zum UI.
+    Scope ``write``."""
+    require_scope(request, "write")
+    db.add(_mk_re_log(request, user, "eps_thresholds_update"))
+    t = await eps_svc.update_thresholds(
+        db, user.id,
+        yoy=data.super_quarter_yoy_pct,
+        accel=data.acceleration_margin_pp,
+        outlier=data.outlier_multiplier,
+    )
+    await db.commit()
+    return {
+        "super_quarter_yoy_pct": t.yoy_threshold,
+        "acceleration_margin_pp": t.acceleration_margin,
+        "outlier_multiplier": t.outlier_multiplier,
+    }
+
+
+# --- Analyse: Resistance + Watchlist-Tags (Write) ---
+
+
+@router.put("/analysis/resistance/{ticker}")
+@limiter.limit(RATE_LIMIT)
+async def resistance_put_external(
+    request: Request,
+    ticker: str,
+    data: ExternalResistanceUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Manuelles Resistance-Level fuer einen Ticker setzen (Positionen +
+    Watchlist) — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services import cache
+
+    tkr = ticker.upper()
+    updated = False
+    pos_rows = await db.execute(select(Position).where(
+        (Position.ticker == tkr) | (Position.yfinance_ticker == tkr),
+        Position.is_active == True, Position.user_id == user.id,
+    ))
+    for pos in pos_rows.scalars().all():
+        pos.manual_resistance = data.manual_resistance
+        updated = True
+    wl_rows = await db.execute(select(WatchlistItem).where(
+        WatchlistItem.ticker == tkr, WatchlistItem.is_active == True,
+        WatchlistItem.user_id == user.id,
+    ))
+    for item in wl_rows.scalars().all():
+        item.manual_resistance = data.manual_resistance
+        updated = True
+    db.add(_mk_re_log(request, user, "resistance_update"))
+    await db.commit()
+    cache.delete(f"scorer_data:{tkr}")
+    return {"ticker": tkr, "manual_resistance": data.manual_resistance, "updated": updated}
+
+
+@router.post("/watchlist/{item_id}/tags", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def watchlist_tag_add_external(
+    request: Request,
+    item_id: uuid.UUID,
+    data: ExternalTagCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Tag an Watchlist-Eintrag haengen (find-or-create) — Paritaet zum UI.
+    Scope ``write``."""
+    require_scope(request, "write")
+    from constants.limits import MAX_WATCHLIST_TAGS_PER_USER
+    from models.watchlist_tag import WatchlistTag, watchlist_item_tags
+
+    TAG_PALETTE = ["#3B82F6", "#10B981", "#F59E0B", "#EF4444", "#8B5CF6", "#EC4899", "#06B6D4", "#6B7280"]
+
+    item = await db.get(WatchlistItem, item_id)
+    if not item or item.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Watchlist-Eintrag nicht gefunden")
+    cnt = await db.scalar(select(func.count()).select_from(watchlist_item_tags).where(
+        watchlist_item_tags.c.watchlist_item_id == item_id,
+    ))
+    if (cnt or 0) >= 5:
+        raise HTTPException(status_code=400, detail="Max. 5 Tags pro Eintrag")
+    tag_name = data.name.strip()[:30]
+    tag = (await db.execute(select(WatchlistTag).where(
+        WatchlistTag.user_id == user.id,
+        func.lower(WatchlistTag.name) == tag_name.lower(),
+    ))).scalars().first()
+    if not tag:
+        tag_count = await db.scalar(select(func.count()).select_from(WatchlistTag).where(
+            WatchlistTag.user_id == user.id,
+        )) or 0
+        if tag_count >= MAX_WATCHLIST_TAGS_PER_USER:
+            raise HTTPException(400, f"Tag-Limit erreicht (max. {MAX_WATCHLIST_TAGS_PER_USER} Tags)")
+        idx = tag_count % len(TAG_PALETTE)
+        tag = WatchlistTag(user_id=user.id, name=tag_name, color=data.color or TAG_PALETTE[idx])
+        db.add(tag)
+        await db.flush()
+    existing = await db.execute(select(watchlist_item_tags).where(
+        watchlist_item_tags.c.watchlist_item_id == item_id,
+        watchlist_item_tags.c.tag_id == tag.id,
+    ))
+    if existing.first():
+        return {"id": str(tag.id), "name": tag.name, "color": tag.color}
+    await db.execute(watchlist_item_tags.insert().values(watchlist_item_id=item_id, tag_id=tag.id))
+    db.add(_mk_re_log(request, user, "watchlist_tag_add", target_id=item_id))
+    await db.commit()
+    return {"id": str(tag.id), "name": tag.name, "color": tag.color}
+
+
+@router.delete("/watchlist/{item_id}/tags/{tag_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def watchlist_tag_remove_external(
+    request: Request,
+    item_id: uuid.UUID,
+    tag_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Tag von Watchlist-Eintrag entfernen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from models.watchlist_tag import watchlist_item_tags
+
+    item = await db.get(WatchlistItem, item_id)
+    if not item or item.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Watchlist-Eintrag nicht gefunden")
+    await db.execute(watchlist_item_tags.delete().where(
+        watchlist_item_tags.c.watchlist_item_id == item_id,
+        watchlist_item_tags.c.tag_id == tag_id,
+    ))
+    db.add(_mk_re_log(request, user, "watchlist_tag_remove", target_id=item_id))
+    await db.commit()
+    return Response(status_code=204)
+
+
+# --- Settings + Onboarding (Write) — ohne Secrets ---
+
+
+@router.patch("/settings")
+@limiter.limit(RATE_LIMIT)
+async def settings_patch_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Benutzer-Einstellungen aendern (Basiswaehrung, Stop-Loss-Defaults, Alert-
+    Toggles, Formate) — Paritaet zum UI. Secrets (API-Keys/SMTP/ntfy) sind hier
+    bewusst NICHT erreichbar. Scope ``write``."""
+    require_scope(request, "write")
+    from api.settings import SettingsUpdate
+    from services import settings_service as svc
+
+    body = await request.json()
+    data = SettingsUpdate(**(body or {}))
+    db.add(_mk_re_log(request, user, "settings_update"))
+    result = await svc.update_settings(db, user.id, data.model_dump(exclude_unset=True))
+    return filter_settings(result if isinstance(result, dict) else {})
+
+
+@router.put("/settings/alert-preferences")
+@limiter.limit(RATE_LIMIT)
+async def alert_preferences_put_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Alert-Praeferenz pro Kategorie setzen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.settings import AlertPrefUpdate
+    from services import settings_service as svc
+
+    body = await request.json()
+    data = AlertPrefUpdate(**(body or {}))
+    db.add(_mk_re_log(request, user, "alert_pref_update"))
+    return await svc.update_alert_preference(
+        db, user.id, data.category, data.is_enabled,
+        data.notify_in_app, data.notify_email, data.notify_push,
+    )
+
+
+@router.post("/settings/onboarding/tour-complete")
+@limiter.limit(RATE_LIMIT)
+async def onboarding_tour_complete_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Onboarding-Tour als abgeschlossen markieren — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services import settings_service as svc
+
+    db.add(_mk_re_log(request, user, "onboarding_update"))
+    result = await svc.mark_tour_complete(db, user.id)
+    return result if isinstance(result, dict) else {"status": "ok"}
+
+
+@router.post("/settings/onboarding/hide-checklist")
+@limiter.limit(RATE_LIMIT)
+async def onboarding_hide_checklist_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Onboarding-Checkliste ausblenden — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services import settings_service as svc
+
+    db.add(_mk_re_log(request, user, "onboarding_update"))
+    result = await svc.hide_checklist(db, user.id)
+    return result if isinstance(result, dict) else {"status": "ok"}
+
+
+@router.post("/settings/onboarding/step-complete")
+@limiter.limit(RATE_LIMIT)
+async def onboarding_step_complete_external(
+    request: Request,
+    data: ExternalOnboardingStep,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Onboarding-Schritt als erledigt markieren — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services import settings_service as svc
+
+    db.add(_mk_re_log(request, user, "onboarding_update"))
+    result = await svc.mark_step_complete(db, user.id, data.step)
+    return result if isinstance(result, dict) else {"status": "ok"}
+
+
+# --- Buckets (Write) — volle Paritaet zum internen UI ---
+#
+# Bucket-Schemas (BucketCreate/Update etc.) werden vom internen Modul
+# wiederverwendet: sie tragen ein verschachteltes ``risk_rules``-Modell, dessen
+# 1:1-Nachbau die Drift-Gefahr eher erhoeht als senkt. Die Response wird ueber
+# ``filter_bucket`` auf den stabilen externen Vertrag verengt.
+
+
+@router.post("/buckets", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def bucket_create_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket anlegen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import BucketCreate, BucketOut, _validate_benchmark
+    from services.bucket_service import BucketError, create_bucket
+
+    payload = BucketCreate(**(await request.json() or {}))
+    benchmark = _validate_benchmark(payload.benchmark)
+    rules = payload.risk_rules.model_dump(exclude_none=True) if payload.risk_rules is not None else None
+    try:
+        bucket = await create_bucket(
+            db, user.id, name=payload.name, color=payload.color, benchmark=benchmark,
+            target_pct=payload.target_pct, target_chf=payload.target_chf,
+            description=payload.description, risk_rules=rules, sort_order=payload.sort_order,
+        )
+    except BucketError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_create", target_id=bucket.id))
+    await db.commit()
+    return filter_bucket(BucketOut.from_model(bucket).model_dump())
+
+
+@router.patch("/buckets/{bucket_id}")
+@limiter.limit(RATE_LIMIT)
+async def bucket_update_external(
+    request: Request,
+    bucket_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket aendern — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import BucketUpdate, BucketOut, _validate_benchmark
+    from services.bucket_service import BucketError, update_bucket
+
+    payload = BucketUpdate(**(await request.json() or {}))
+    benchmark = _validate_benchmark(payload.benchmark) if payload.benchmark is not None else None
+    rules = payload.risk_rules.model_dump(exclude_none=True) if payload.risk_rules is not None else None
+    try:
+        bucket = await update_bucket(
+            db, user.id, bucket_id, name=payload.name, color=payload.color, benchmark=benchmark,
+            target_pct=payload.target_pct, target_chf=payload.target_chf,
+            description=payload.description, risk_rules=rules, sort_order=payload.sort_order,
+        )
+    except BucketError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_update", target_id=bucket_id))
+    await db.commit()
+    return filter_bucket(BucketOut.from_model(bucket).model_dump())
+
+
+@router.delete("/buckets/{bucket_id}")
+@limiter.limit(RATE_LIMIT)
+async def bucket_delete_external(
+    request: Request,
+    bucket_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket loeschen (Positionen wandern in den Liquid-Default) — Paritaet zum
+    UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.bucket_service import BucketError, delete_bucket
+
+    try:
+        moved = await delete_bucket(db, user.id, bucket_id)
+    except BucketError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_delete", target_id=bucket_id))
+    await db.commit()
+    if moved > 0:
+        from api.portfolio import invalidate_portfolio_cache
+        invalidate_portfolio_cache(str(user.id))
+    return {"deleted": True, "positions_moved": moved}
+
+
+@router.post("/buckets/from-template", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def bucket_from_template_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket-Set aus Vorlage anlegen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import TemplateApply, BucketOut
+    from services.bucket_service import BucketError
+    from services.bucket_templates import apply_template
+
+    payload = TemplateApply(**(await request.json() or {}))
+    try:
+        created = await apply_template(db, user.id, payload.template_key, replace_existing=payload.replace_existing)
+    except BucketError as e:
+        await db.rollback()
+        msg = str(e)
+        if msg.startswith("Bucket-Namen existieren bereits"):
+            raise HTTPException(status_code=409, detail={"error": "bucket_name_conflict", "message": msg, "can_replace": True})
+        raise HTTPException(status_code=400, detail=msg)
+    db.add(_mk_re_log(request, user, "bucket_from_template"))
+    await db.commit()
+    return {"created": [filter_bucket(BucketOut.from_model(b).model_dump()) for b in created], "count": len(created)}
+
+
+@router.post("/buckets/migration-rollback")
+@limiter.limit(RATE_LIMIT)
+async def bucket_migration_rollback_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket-Migration zurueckrollen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.bucket_service import migration_rollback
+
+    result = await migration_rollback(db, user.id)
+    db.add(_mk_re_log(request, user, "bucket_migration_rollback"))
+    await db.commit()
+    if result.get("positions_moved", 0) > 0:
+        from api.portfolio import invalidate_portfolio_cache
+        invalidate_portfolio_cache(str(user.id))
+    return result
+
+
+@router.post("/positions/by-id/{position_id}/split-to-bucket")
+@limiter.limit(RATE_LIMIT)
+async def bucket_split_position_external(
+    request: Request,
+    position_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Position teilweise in anderen Bucket splitten — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import SplitPosition
+    from services.bucket_service import BucketError, split_position_to_bucket
+
+    payload = SplitPosition(**(await request.json() or {}))
+    try:
+        target_uuid = uuid.UUID(payload.target_bucket_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Ungueltige Bucket-ID")
+    try:
+        original, new_pos = await split_position_to_bucket(
+            db, user.id, position_id, target_uuid, split_pct=payload.split_pct, note=payload.note,
+        )
+    except BucketError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_split_position", target_id=position_id))
+    await db.commit()
+    from api.portfolio import invalidate_portfolio_cache
+    invalidate_portfolio_cache(str(user.id))
+    return {
+        "original_position": {"id": str(original.id), "shares": float(original.shares), "cost_basis_chf": float(original.cost_basis_chf)},
+        "new_position": {"id": str(new_pos.id), "bucket_id": str(new_pos.bucket_id), "shares": float(new_pos.shares), "cost_basis_chf": float(new_pos.cost_basis_chf)},
+    }
+
+
+@router.post("/positions/by-id/{position_id}/move-to-bucket")
+@limiter.limit(RATE_LIMIT)
+async def bucket_move_position_external(
+    request: Request,
+    position_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Position in anderen Bucket verschieben — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import MovePosition
+    from services.bucket_service import BucketError, move_position_to_bucket
+
+    payload = MovePosition(**(await request.json() or {}))
+    try:
+        target_uuid = uuid.UUID(payload.target_bucket_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Ungueltige Bucket-ID")
+    try:
+        position = await move_position_to_bucket(
+            db, user.id, position_id, target_uuid, changed_by="user",
+            note=payload.note, keep_risk_rules=payload.keep_risk_rules,
+        )
+    except BucketError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_move_position", target_id=position_id))
+    await db.commit()
+    from api.portfolio import invalidate_portfolio_cache
+    invalidate_portfolio_cache(str(user.id))
+    return {"position_id": str(position.id), "ticker": position.ticker, "bucket_id": str(position.bucket_id)}
+
+
+@router.post("/buckets/import-rules", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def bucket_import_rule_create_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Import-Bucket-Mapping-Regel anlegen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.buckets import ImportRuleCreate
+    from services.import_bucket_rule_service import ImportRuleError, create_rule
+
+    payload = ImportRuleCreate(**(await request.json() or {}))
+    try:
+        bucket_uuid = uuid.UUID(payload.bucket_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Ungueltige Bucket-ID")
+    try:
+        rule = await create_rule(
+            db, user.id, bucket_id=bucket_uuid, source=payload.source,
+            ticker_pattern=payload.ticker_pattern, priority=payload.priority,
+        )
+    except ImportRuleError as e:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    db.add(_mk_re_log(request, user, "bucket_import_rule_create", target_id=rule.id))
+    await db.commit()
+    return {
+        "id": str(rule.id), "bucket_id": str(rule.bucket_id), "source": rule.source,
+        "ticker_pattern": rule.ticker_pattern, "priority": rule.priority,
+    }
+
+
+@router.delete("/buckets/import-rules/{rule_id}")
+@limiter.limit(RATE_LIMIT)
+async def bucket_import_rule_delete_external(
+    request: Request,
+    rule_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Import-Bucket-Mapping-Regel loeschen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.import_bucket_rule_service import delete_rule
+
+    deleted = await delete_rule(db, user.id, rule_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Regel nicht gefunden")
+    db.add(_mk_re_log(request, user, "bucket_import_rule_del", target_id=rule_id))
+    await db.commit()
+    return {"deleted": True}
+
+
+@router.post("/buckets/backfill-snapshots")
+@limiter.limit(RATE_LIMIT)
+async def bucket_backfill_snapshots_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket-Snapshots rueckwirkend aus Portfolio-Snapshots backfillen — Paritaet
+    zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.bucket_snapshot_backfill_service import backfill_bucket_snapshots
+
+    result = await backfill_bucket_snapshots(db, user.id)
+    db.add(_mk_re_log(request, user, "bucket_backfill_snapshots"))
+    await db.commit()
+    return result
+
+
+@router.post("/buckets/onboarding-dismiss")
+@limiter.limit(RATE_LIMIT)
+async def bucket_onboarding_dismiss_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Bucket-Migrations-Modal ohne Rollback schliessen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from models.user import UserSettings
+
+    settings = (await db.execute(select(UserSettings).where(UserSettings.user_id == user.id))).scalar_one_or_none()
+    if settings is not None:
+        settings.noticed_buckets_migration = True
+    db.add(_mk_re_log(request, user, "bucket_onboarding_dismiss"))
+    await db.commit()
+    return {"noticed_buckets_migration": True}
+
+
+# --- Import-Flow (Write) — CSV-Upload, Mapping, Confirm, Profile ---
+#
+# parse/analyze/parse-with-mapping spiegeln die internen Multipart- bzw. JSON-
+# Endpoints; ``confirm`` ist der eigentliche Schreibvorgang (Bulk-Insert +
+# Recalc + Snapshot-Regen). Schemas (ConfirmRequest/ProfileCreate/
+# ParseWithMappingRequest) werden vom internen Modul wiederverwendet.
+
+_IMPORT_MAX_FILE = 10 * 1024 * 1024
+
+
+@router.post("/import/parse")
+@limiter.limit(RATE_LIMIT)
+async def import_parse_external(
+    request: Request,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """CSV hochladen + parsen (Vorschau) — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from services.import_service import parse_csv
+
+    fn = file.filename or ""
+    if not fn.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="Nur CSV-Dateien erlaubt")
+    content = await file.read()
+    if len(content) > _IMPORT_MAX_FILE:
+        raise HTTPException(status_code=400, detail="Datei zu gross (max. 10 MB)")
+    if len(content) == 0:
+        raise HTTPException(status_code=400, detail="Datei ist leer")
+    try:
+        preview = await parse_csv(content, fn, db, user_id=user.id)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    # Audit-Log erst NACH erfolgreichem Parse — ein 422 soll keinen
+    # irrefuehrenden "Erfolgs"-Log hinterlassen (Audit v0.45 Finding #1).
+    db.add(_mk_re_log(request, user, "import_parse"))
+    await db.commit()
+    return preview.model_dump() if hasattr(preview, "model_dump") else preview
+
+
+@router.post("/import/analyze")
+@limiter.limit(RATE_LIMIT)
+async def import_analyze_external(
+    request: Request,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """CSV-Struktur analysieren (Encoding/Delimiter/Header/Broker) — Paritaet zum
+    UI. Scope ``write`` (legt Temp-Upload an)."""
+    require_scope(request, "write")
+    from services.import_service import analyze_csv_structure
+
+    fn = file.filename or ""
+    if not fn.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="Nur CSV-Dateien erlaubt")
+    content = await file.read()
+    if len(content) > _IMPORT_MAX_FILE:
+        raise HTTPException(status_code=400, detail="Datei zu gross (max. 10 MB)")
+    if not content:
+        raise HTTPException(status_code=400, detail="Datei ist leer")
+    try:
+        result = await analyze_csv_structure(content, fn, db, user.id)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    # Log erst nach erfolgreicher Analyse (Audit v0.45 Finding #1).
+    db.add(_mk_re_log(request, user, "import_parse"))
+    await db.commit()
+    return result
+
+
+@router.post("/import/parse-with-mapping")
+@limiter.limit(RATE_LIMIT)
+async def import_parse_with_mapping_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Zuvor hochgeladene CSV mit explizitem Spalten-Mapping parsen — Paritaet
+    zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    import os as _os
+    from api.imports import ParseWithMappingRequest, UPLOAD_DIR
+    from services.import_service import parse_csv
+
+    data = ParseWithMappingRequest(**(await request.json() or {}))
+    try:
+        uuid.UUID(data.upload_id)
+    except ValueError:
+        raise HTTPException(400, "Ungueltige Upload-ID")
+    user_dir = _os.path.join(UPLOAD_DIR, str(user.id))
+    filepath = _os.path.join(user_dir, f"{data.upload_id}.csv")
+    if not _os.path.realpath(filepath).startswith(_os.path.realpath(user_dir) + _os.sep):
+        raise HTTPException(400, "Ungueltige Upload-ID")
+    if not _os.path.exists(filepath):
+        raise HTTPException(404, "Upload nicht gefunden. Bitte CSV erneut hochladen.")
+    with open(filepath, "rb") as f:
+        content = f.read()
+    column_mapping, type_mapping, date_format = data.column_mapping, data.type_mapping, data.date_format
+    if data.profile_id:
+        from models.import_profile import ImportProfile
+        try:
+            profile_uuid = uuid.UUID(data.profile_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Ungueltige Profil-ID")
+        profile = await db.get(ImportProfile, profile_uuid)
+        if profile and profile.user_id == user.id:
+            column_mapping, type_mapping = profile.column_mapping, profile.type_mapping
+            if profile.date_format:
+                date_format = profile.date_format
+    try:
+        preview = await parse_csv(
+            content, f"upload_{data.upload_id}.csv", db,
+            user_mapping=column_mapping, user_id=user.id, type_mapping=type_mapping,
+            broker_defaults=data.broker_defaults, total_chf_formula=data.total_chf_formula,
+            date_format=date_format,
+        )
+    except ValueError as e:
+        raise HTTPException(422, str(e))
+    # Log erst nach erfolgreichem Parse (Audit v0.45 Finding #1).
+    db.add(_mk_re_log(request, user, "import_parse"))
+    await db.commit()
+    return preview.model_dump() if hasattr(preview, "model_dump") else preview
+
+
+@router.post("/import/confirm", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def import_confirm_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Geparste Transaktionen bestaetigen + bulk-inserten (inkl. Recalc +
+    Snapshot-Regen) — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    import asyncio as _asyncio
+    from api.imports import ConfirmRequest, _bg_tasks
+    from db import async_session
+    from services.import_service import confirm_import
+    from services.recalculate_service import recalculate_all_positions
+
+    data = ConfirmRequest(**(await request.json() or {}))
+    db.add(_mk_re_log(request, user, "import_confirm"))
+    txn_dicts = [t.model_dump(exclude_none=True) for t in data.transactions]
+    pos_dicts = [p.model_dump(exclude_none=True) for p in data.new_positions]
+    fx_dicts = [f.model_dump(exclude_none=True) for f in data.fx_transactions]
+    result = await confirm_import(txn_dicts, pos_dicts, db, user.id, fx_transactions=fx_dicts)
+    recalc_results = await recalculate_all_positions(db, user_id=user.id)
+    result["recalculated_positions"] = len([r for r in recalc_results if "error" not in r])
+
+    async def _regenerate_bg(uid):
+        from services.snapshot_service import regenerate_snapshots
+        try:
+            async with async_session() as bg_db:
+                await regenerate_snapshots(bg_db, uid)
+        except Exception as exc:
+            logger.error(f"Background snapshot regeneration failed: {exc}", exc_info=True)
+
+    task = _asyncio.create_task(_regenerate_bg(user.id))
+    _bg_tasks.add(task)
+    task.add_done_callback(_bg_tasks.discard)
+    from api.portfolio import invalidate_portfolio_cache
+    invalidate_portfolio_cache(str(user.id))
+    return result
+
+
+@router.get("/import/profiles")
+@limiter.limit(RATE_LIMIT)
+async def import_profiles_list_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> list:
+    """Import-Profile auflisten — Paritaet zum UI."""
+    from models.import_profile import ImportProfile
+
+    rows = (await db.execute(
+        select(ImportProfile).where(ImportProfile.user_id == user.id).order_by(ImportProfile.name)
+    )).scalars().all()
+    return [
+        {
+            "id": str(p.id), "name": p.name, "column_mapping": p.column_mapping,
+            "type_mapping": p.type_mapping, "delimiter": p.delimiter, "encoding": p.encoding,
+            "date_format": p.date_format, "decimal_separator": p.decimal_separator,
+            "has_forex_pairs": p.has_forex_pairs, "aggregate_partial_fills": p.aggregate_partial_fills,
+        }
+        for p in rows
+    ]
+
+
+@router.post("/import/profiles", status_code=201)
+@limiter.limit(RATE_LIMIT)
+async def import_profile_create_external(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> dict:
+    """Import-Profil anlegen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from api.imports import ProfileCreate
+    from constants.limits import MAX_IMPORT_PROFILES_PER_USER
+    from models.import_profile import ImportProfile
+
+    data = ProfileCreate(**(await request.json() or {}))
+    cnt = await db.scalar(select(func.count()).select_from(ImportProfile).where(ImportProfile.user_id == user.id)) or 0
+    if cnt >= MAX_IMPORT_PROFILES_PER_USER:
+        raise HTTPException(400, f"Limit erreicht (max. {MAX_IMPORT_PROFILES_PER_USER} Import-Profile)")
+    profile = ImportProfile(
+        user_id=user.id, name=data.name, column_mapping=data.column_mapping,
+        type_mapping=data.type_mapping, delimiter=data.delimiter, encoding=data.encoding,
+        date_format=data.date_format, decimal_separator=data.decimal_separator,
+        has_forex_pairs=data.has_forex_pairs, aggregate_partial_fills=data.aggregate_partial_fills,
+    )
+    db.add(profile)
+    await db.flush()
+    log = _mk_re_log(request, user, "import_profile_create", target_id=profile.id)
+    db.add(log)
+    await db.commit()
+    await db.refresh(profile)
+    return {"id": str(profile.id), "name": profile.name}
+
+
+@router.delete("/import/profiles/{profile_id}", status_code=204)
+@limiter.limit(RATE_LIMIT)
+async def import_profile_delete_external(
+    request: Request,
+    profile_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_api_user),
+) -> Response:
+    """Import-Profil loeschen — Paritaet zum UI. Scope ``write``."""
+    require_scope(request, "write")
+    from models.import_profile import ImportProfile
+
+    profile = await db.get(ImportProfile, profile_id)
+    if not profile or profile.user_id != user.id:
+        raise HTTPException(404, "Profil nicht gefunden")
+    db.add(_mk_re_log(request, user, "import_profile_delete", target_id=profile_id))
+    await db.delete(profile)
+    await db.commit()
+    return Response(status_code=204)

--- a/backend/api/external_v1_schemas.py
+++ b/backend/api/external_v1_schemas.py
@@ -476,6 +476,67 @@ class ExternalTransactionUpdate(_StrictWrite):
     notes: Optional[str] = Field(default=None, max_length=2000)
 
 
+# --- Positionen (Write) ---
+#
+# Whitelist-Mirror des internen ``PositionCreate`` / ``PositionUpdate``
+# (api/positions.py). Bewusst entkoppelt (Vertragsentscheidung 3): interne
+# Felderweiterungen werden NICHT automatisch extern akzeptiert. Enum-Werte
+# (type/pricing_mode/style/price_source) werden als String exponiert und vom
+# internen Schema gegen die Python-Enums validiert.
+
+class ExternalPositionCreate(_StrictWrite):
+    ticker: str = Field(min_length=1, max_length=60)
+    name: str = Field(min_length=1, max_length=200)
+    type: Literal[
+        "stock", "etf", "crypto", "commodity", "cash",
+        "real_estate", "private_equity", "pension",
+    ]
+    sector: Optional[str] = Field(default=None, max_length=100)
+    industry: Optional[str] = Field(default=None, max_length=100)
+    currency: str = Field(default="CHF", min_length=3, max_length=3)
+    pricing_mode: Optional[Literal["auto", "manual"]] = None
+    style: Optional[str] = Field(default=None, max_length=50)
+    bucket_id: Optional[uuid.UUID] = None
+    yfinance_ticker: Optional[str] = Field(default=None, max_length=60)
+    coingecko_id: Optional[str] = Field(default=None, max_length=100)
+    gold_org: bool = False
+    price_source: Optional[Literal["yahoo", "coingecko", "manual", "gold_org"]] = None
+    isin: Optional[str] = Field(default=None, max_length=20)
+    shares: float = Field(default=0, ge=0)
+    cost_basis_chf: float = Field(default=0, ge=0)
+    current_price: Optional[float] = Field(default=None, ge=0)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    bank_name: Optional[str] = Field(default=None, max_length=200)
+    iban: Optional[str] = Field(default=None, max_length=34)
+
+
+class ExternalPositionUpdate(_StrictWrite):
+    ticker: Optional[str] = Field(default=None, min_length=1, max_length=60)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    type: Optional[Literal[
+        "stock", "etf", "crypto", "commodity", "cash",
+        "real_estate", "private_equity", "pension",
+    ]] = None
+    sector: Optional[str] = Field(default=None, max_length=100)
+    industry: Optional[str] = Field(default=None, max_length=100)
+    currency: Optional[str] = Field(default=None, min_length=3, max_length=3)
+    pricing_mode: Optional[Literal["auto", "manual"]] = None
+    style: Optional[str] = Field(default=None, max_length=50)
+    yfinance_ticker: Optional[str] = Field(default=None, max_length=60)
+    coingecko_id: Optional[str] = Field(default=None, max_length=100)
+    gold_org: Optional[bool] = None
+    price_source: Optional[Literal["yahoo", "coingecko", "manual", "gold_org"]] = None
+    isin: Optional[str] = Field(default=None, max_length=20)
+    shares: Optional[float] = Field(default=None, ge=0)
+    cost_basis_chf: Optional[float] = Field(default=None, ge=0)
+    current_price: Optional[float] = Field(default=None, ge=0)
+    manual_resistance: Optional[float] = Field(default=None, ge=0)
+    is_active: Optional[bool] = None
+    bank_name: Optional[str] = Field(default=None, max_length=200)
+    iban: Optional[str] = Field(default=None, max_length=34)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
 # --- Stop-Loss ---
 #
 # Whitelist-Schemas analog zum internen ``StopLossUpdate`` /
@@ -550,3 +611,327 @@ class ReportPatch(_Strict):
     report_date: Optional[_date] = None
     body: Optional[str] = Field(default=None, min_length=1, max_length=200_000)
     tags: Optional[list[str]] = Field(default=None)
+
+
+# --- Immobilien (Write) ---
+#
+# Whitelist-Mirror der internen Schemas in api/real_estate.py. Enums werden als
+# Literal exponiert und vom internen Schema validiert.
+
+class ExternalPropertyCreate(_StrictWrite):
+    name: str = Field(min_length=1, max_length=200)
+    address: Optional[str] = Field(default=None, max_length=500)
+    property_type: Literal["efh", "mfh", "stockwerk", "grundstueck"]
+    purchase_date: Optional[_date] = None
+    purchase_price: float = Field(ge=0)
+    estimated_value: Optional[float] = Field(default=None, ge=0)
+    estimated_value_date: Optional[_date] = None
+    land_area_m2: Optional[float] = Field(default=None, ge=0)
+    living_area_m2: Optional[float] = Field(default=None, ge=0)
+    rooms: Optional[float] = Field(default=None, ge=0, le=100)
+    year_built: Optional[int] = Field(default=None, ge=1800, le=2100)
+    canton: Optional[str] = Field(default=None, max_length=2)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalPropertyUpdate(_StrictWrite):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    address: Optional[str] = Field(default=None, max_length=500)
+    property_type: Optional[Literal["efh", "mfh", "stockwerk", "grundstueck"]] = None
+    purchase_date: Optional[_date] = None
+    purchase_price: Optional[float] = Field(default=None, ge=0)
+    estimated_value: Optional[float] = Field(default=None, ge=0)
+    estimated_value_date: Optional[_date] = None
+    land_area_m2: Optional[float] = Field(default=None, ge=0)
+    living_area_m2: Optional[float] = Field(default=None, ge=0)
+    rooms: Optional[float] = Field(default=None, ge=0, le=100)
+    year_built: Optional[int] = Field(default=None, ge=1800, le=2100)
+    canton: Optional[str] = Field(default=None, max_length=2)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalMortgageCreate(_StrictWrite):
+    name: str = Field(min_length=1, max_length=200)
+    type: Literal["fixed", "saron", "variable"]
+    amount: float = Field(gt=0)
+    interest_rate: float = Field(ge=0, le=100)
+    margin_rate: Optional[float] = Field(default=None, ge=0, le=100)
+    start_date: Optional[_date] = None
+    end_date: Optional[_date] = None
+    monthly_payment: Optional[float] = Field(default=None, ge=0)
+    annual_payment: Optional[float] = Field(default=None, ge=0)
+    amortization_monthly: Optional[float] = Field(default=None, ge=0)
+    amortization_annual: Optional[float] = Field(default=None, ge=0)
+    bank: Optional[str] = Field(default=None, max_length=200)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalMortgageUpdate(_StrictWrite):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    type: Optional[Literal["fixed", "saron", "variable"]] = None
+    amount: Optional[float] = Field(default=None, gt=0)
+    interest_rate: Optional[float] = Field(default=None, ge=0, le=100)
+    margin_rate: Optional[float] = Field(default=None, ge=0, le=100)
+    start_date: Optional[_date] = None
+    end_date: Optional[_date] = None
+    monthly_payment: Optional[float] = Field(default=None, ge=0)
+    annual_payment: Optional[float] = Field(default=None, ge=0)
+    amortization_monthly: Optional[float] = Field(default=None, ge=0)
+    amortization_annual: Optional[float] = Field(default=None, ge=0)
+    bank: Optional[str] = Field(default=None, max_length=200)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalPropertyExpenseCreate(_StrictWrite):
+    date: _date
+    category: Literal["insurance", "utilities", "maintenance", "repair", "tax", "other"]
+    description: Optional[str] = Field(default=None, max_length=500)
+    amount: float = Field(gt=0)
+    recurring: bool = False
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+class ExternalPropertyExpenseUpdate(_StrictWrite):
+    date: Optional[_date] = None
+    category: Optional[Literal["insurance", "utilities", "maintenance", "repair", "tax", "other"]] = None
+    description: Optional[str] = Field(default=None, max_length=500)
+    amount: Optional[float] = Field(default=None, gt=0)
+    recurring: Optional[bool] = None
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+class ExternalPropertyIncomeCreate(_StrictWrite):
+    date: _date
+    description: Optional[str] = Field(default=None, max_length=500)
+    amount: float = Field(gt=0)
+    tenant: Optional[str] = Field(default=None, max_length=200)
+    recurring: bool = False
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+class ExternalPropertyIncomeUpdate(_StrictWrite):
+    date: Optional[_date] = None
+    description: Optional[str] = Field(default=None, max_length=500)
+    amount: Optional[float] = Field(default=None, gt=0)
+    tenant: Optional[str] = Field(default=None, max_length=200)
+    recurring: Optional[bool] = None
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+# --- Private Equity (Write) ---
+
+class ExternalPEHoldingCreate(_StrictWrite):
+    company_name: str = Field(min_length=1, max_length=200)
+    num_shares: int = Field(gt=0)
+    nominal_value: float = Field(ge=0)
+    purchase_price_per_share: Optional[float] = Field(default=None, ge=0)
+    purchase_date: Optional[_date] = None
+    currency: str = Field(default="CHF", max_length=3)
+    uid_number: Optional[str] = Field(default=None, max_length=50)
+    register_nr: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = Field(default=None, max_length=1000)
+
+
+class ExternalPEHoldingUpdate(_StrictWrite):
+    company_name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    num_shares: Optional[int] = Field(default=None, gt=0)
+    nominal_value: Optional[float] = Field(default=None, ge=0)
+    purchase_price_per_share: Optional[float] = Field(default=None, ge=0)
+    purchase_date: Optional[_date] = None
+    currency: Optional[str] = Field(default=None, max_length=3)
+    uid_number: Optional[str] = Field(default=None, max_length=50)
+    register_nr: Optional[str] = Field(default=None, max_length=50)
+    notes: Optional[str] = Field(default=None, max_length=1000)
+
+
+class ExternalPEValuationCreate(_StrictWrite):
+    valuation_date: _date
+    gross_value_per_share: float = Field(ge=0)
+    discount_pct: float = Field(default=30.0, ge=0, le=100)
+    source: Optional[str] = Field(default=None, max_length=100)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+class ExternalPEValuationUpdate(_StrictWrite):
+    valuation_date: Optional[_date] = None
+    gross_value_per_share: Optional[float] = Field(default=None, ge=0)
+    discount_pct: Optional[float] = Field(default=None, ge=0, le=100)
+    source: Optional[str] = Field(default=None, max_length=100)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+class ExternalPEDividendCreate(_StrictWrite):
+    payment_date: _date
+    dividend_per_share: float = Field(ge=0)
+    withholding_tax_pct: float = Field(default=35.0, ge=0, le=100)
+    fiscal_year: int = Field(ge=1900, le=2100)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+class ExternalPEDividendUpdate(_StrictWrite):
+    payment_date: Optional[_date] = None
+    dividend_per_share: Optional[float] = Field(default=None, ge=0)
+    withholding_tax_pct: Optional[float] = Field(default=None, ge=0, le=100)
+    fiscal_year: Optional[int] = Field(default=None, ge=1900, le=2100)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+EXTERNAL_PE_VALUATION_FIELDS = {
+    "id", "valuation_date", "gross_value_per_share", "discount_pct",
+    "net_value_per_share", "source", "notes",
+}
+EXTERNAL_PE_DIVIDEND_FIELDS = {
+    "id", "payment_date", "dividend_per_share", "gross_amount",
+    "withholding_tax_pct", "withholding_tax_amount", "net_amount",
+    "fiscal_year", "notes",
+}
+EXTERNAL_PE_HOLDING_FIELDS = {
+    "id", "company_name", "num_shares", "nominal_value",
+    "purchase_price_per_share", "purchase_date", "currency", "uid_number",
+    "register_nr", "notes", "is_active", "latest_valuation",
+    "gross_value_per_share", "net_value_per_share", "total_gross_value",
+    "total_net_value", "total_dividends_net", "dividend_yield_pct",
+    "created_at", "valuations", "dividends",
+}
+
+
+def filter_pe_holding(h: dict) -> dict:
+    """Whitelist-Filter für PE-Holding-Dicts (rekursiv für valuations/dividends).
+    PII (company_name/uid_number/register_nr/notes) bleibt — Daten des
+    Token-Eigentümers (v0.38-Vertrag)."""
+    out = {k: v for k, v in h.items() if k in EXTERNAL_PE_HOLDING_FIELDS}
+    if isinstance(out.get("valuations"), list):
+        out["valuations"] = [
+            {k: v for k, v in val.items() if k in EXTERNAL_PE_VALUATION_FIELDS}
+            for val in out["valuations"]
+        ]
+    if isinstance(out.get("dividends"), list):
+        out["dividends"] = [
+            {k: v for k, v in d.items() if k in EXTERNAL_PE_DIVIDEND_FIELDS}
+            for d in out["dividends"]
+        ]
+    if isinstance(out.get("latest_valuation"), dict):
+        out["latest_valuation"] = {
+            k: v for k, v in out["latest_valuation"].items()
+            if k in EXTERNAL_PE_VALUATION_FIELDS
+        }
+    return out
+
+
+# --- Edelmetalle (Write) ---
+
+class ExternalMetalCreate(_StrictWrite):
+    metal_type: Literal["gold", "silver", "platinum", "palladium"]
+    form: Literal["bar", "coin", "other"]
+    manufacturer: Optional[str] = Field(default=None, max_length=200)
+    weight_grams: float = Field(gt=0)
+    serial_number: Optional[str] = Field(default=None, max_length=100)
+    fineness: Optional[str] = Field(default=None, max_length=10)
+    purchase_date: _date
+    purchase_price_chf: float = Field(ge=0)
+    storage_location: Optional[str] = Field(default=None, max_length=500)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalMetalUpdate(_StrictWrite):
+    metal_type: Optional[Literal["gold", "silver", "platinum", "palladium"]] = None
+    form: Optional[Literal["bar", "coin", "other"]] = None
+    manufacturer: Optional[str] = Field(default=None, max_length=200)
+    weight_grams: Optional[float] = Field(default=None, gt=0)
+    serial_number: Optional[str] = Field(default=None, max_length=100)
+    fineness: Optional[str] = Field(default=None, max_length=10)
+    purchase_date: Optional[_date] = None
+    purchase_price_chf: Optional[float] = Field(default=None, ge=0)
+    storage_location: Optional[str] = Field(default=None, max_length=500)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    is_sold: Optional[bool] = None
+    sold_date: Optional[_date] = None
+    sold_price_chf: Optional[float] = Field(default=None, ge=0)
+
+
+class ExternalMetalExpenseCreate(_StrictWrite):
+    metal_type: Optional[Literal["gold", "silver", "platinum", "palladium"]] = None
+    date: _date
+    category: Literal["storage", "insurance", "other"]
+    description: Optional[str] = Field(default=None, max_length=300)
+    amount: float = Field(gt=0)
+    recurring: bool = False
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+class ExternalMetalExpenseUpdate(_StrictWrite):
+    metal_type: Optional[Literal["gold", "silver", "platinum", "palladium"]] = None
+    date: Optional[_date] = None
+    category: Optional[Literal["storage", "insurance", "other"]] = None
+    description: Optional[str] = Field(default=None, max_length=300)
+    amount: Optional[float] = Field(default=None, gt=0)
+    recurring: Optional[bool] = None
+    frequency: Optional[Literal["monthly", "quarterly", "yearly", "once"]] = None
+
+
+EXTERNAL_METAL_ITEM_FIELDS = {
+    "id", "metal_type", "form", "manufacturer", "weight_grams", "weight_oz",
+    "serial_number", "fineness", "purchase_date", "purchase_price_chf",
+    "storage_location", "is_sold", "sold_date", "sold_price_chf", "notes",
+    "created_at",
+}
+EXTERNAL_METAL_EXPENSE_FIELDS = {
+    "id", "metal_type", "date", "category", "description", "amount",
+    "recurring", "frequency", "created_at",
+}
+
+
+def filter_metal_item(d: dict) -> dict:
+    """Whitelist-Filter für Edelmetall-Item-Dicts (PII des Eigentümers bleibt)."""
+    return {k: v for k, v in d.items() if k in EXTERNAL_METAL_ITEM_FIELDS}
+
+
+def filter_metal_expense(d: dict) -> dict:
+    """Whitelist-Filter für Edelmetall-Ausgaben-Dicts."""
+    return {k: v for k, v in d.items() if k in EXTERNAL_METAL_EXPENSE_FIELDS}
+
+
+# --- Dividenden (Write) ---
+
+class ExternalDividendConfirm(_StrictWrite):
+    date: _date
+    total_chf: float = Field(ge=0)
+    gross_amount: Optional[float] = Field(default=None, ge=0)
+    currency: Optional[str] = Field(default=None, min_length=3, max_length=10)
+    fx_rate_to_chf: float = Field(default=1.0, gt=0)
+    withholding_pct: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ExternalDividendDismiss(_StrictWrite):
+    reason: Optional[str] = Field(default=None, max_length=500)
+
+
+# --- Analyse / ETF / EPS / Onboarding (Write) ---
+
+class ExternalResistanceUpdate(_StrictWrite):
+    manual_resistance: Optional[float] = Field(default=None, ge=0)
+
+
+class ExternalTagCreate(_StrictWrite):
+    name: str = Field(min_length=1, max_length=30)
+    color: Optional[str] = Field(default=None, max_length=7)
+
+
+class ExternalEtfSectorWeight(_StrictWrite):
+    sector: str = Field(min_length=1, max_length=100)
+    weight_pct: float = Field(ge=0, le=100)
+
+
+class ExternalEtfSectorWeights(_StrictWrite):
+    sectors: list[ExternalEtfSectorWeight] = Field(min_length=1, max_length=20)
+
+
+class ExternalEpsThresholds(_StrictWrite):
+    super_quarter_yoy_pct: Optional[float] = Field(default=None, gt=0, le=200)
+    acceleration_margin_pp: Optional[float] = Field(default=None, gt=0, le=200)
+    outlier_multiplier: Optional[float] = Field(default=None, gt=0, le=20)
+
+
+class ExternalOnboardingStep(_StrictWrite):
+    step: str = Field(min_length=1, max_length=100)

--- a/backend/api/positions.py
+++ b/backend/api/positions.py
@@ -22,6 +22,7 @@ from services.recalculate_service import recalculate_position, recalculate_all_p
 from services.sector_mapping import INDUSTRY_TO_SECTOR
 from api.auth import limiter
 from api.portfolio import invalidate_portfolio_cache
+from models.api_write_log import ApiWriteLog
 from services.encryption_helpers import encrypt_field, decrypt_field, decrypt_and_mask_iban
 from constants.limits import MAX_POSITIONS_PER_USER
 
@@ -140,9 +141,16 @@ async def get_position(position_id: uuid.UUID, db: AsyncSession = Depends(get_db
 
 
 
-@router.post("/positions", status_code=201)
-@limiter.limit("30/minute")
-async def create_position(request: Request, data: PositionCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def create_position_core(
+    db: AsyncSession,
+    user: User,
+    data: PositionCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen einer Position — geteilt zwischen internem UI-
+    Endpoint und externer API. Bei gesetztem ``audit_log`` wird dieser atomar mit
+    der Position committet (Ticker/target_id werden nach dem Flush gesetzt)."""
     # Per-user limit
     count = await db.scalar(select(func.count(Position.id)).where(Position.user_id == user.id))
     if count >= MAX_POSITIONS_PER_USER:
@@ -215,6 +223,17 @@ async def create_position(request: Request, data: PositionCreate, db: AsyncSessi
     pos = Position(**dump, user_id=user.id)
     db.add(pos)
     try:
+        await db.flush()
+    except Exception as e:
+        await db.rollback()
+        if "unique" in str(e).lower() or "duplicate" in str(e).lower():
+            raise HTTPException(409, "Eine Position mit diesem Namen existiert bereits.")
+        raise HTTPException(500, "Position konnte nicht erstellt werden.")
+    if audit_log is not None:
+        audit_log.ticker = (pos.ticker or "")[:30]
+        audit_log.target_id = pos.id
+        db.add(audit_log)
+    try:
         await db.commit()
     except Exception as e:
         await db.rollback()
@@ -234,9 +253,21 @@ async def create_position(request: Request, data: PositionCreate, db: AsyncSessi
     return _pos_to_dict(pos)
 
 
-@router.put("/positions/{position_id}")
+@router.post("/positions", status_code=201)
 @limiter.limit("30/minute")
-async def update_position(request: Request, position_id: uuid.UUID, data: PositionUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def create_position(request: Request, data: PositionCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    return await create_position_core(db, user, data)
+
+
+async def update_position_core(
+    db: AsyncSession,
+    user: User,
+    position_id: uuid.UUID,
+    data: PositionUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aendern einer Position — geteilt mit der externen API."""
     pos = await db.get(Position, position_id)
     if not pos or pos.user_id != user.id:
         raise HTTPException(status_code=404, detail="Position nicht gefunden")
@@ -264,24 +295,49 @@ async def update_position(request: Request, position_id: uuid.UUID, data: Positi
     # Der dedizierte PATCH-Pfad (stoploss_service) macht das immer.
     if any(k in updates for k in ("stop_loss_price", "stop_loss_method", "stop_loss_confirmed_at_broker")):
         pos.stop_loss_updated_at = utcnow()
+    if audit_log is not None:
+        audit_log.ticker = (pos.ticker or "")[:30]
+        audit_log.target_id = pos.id
+        db.add(audit_log)
     await db.commit()
     await db.refresh(pos)
     invalidate_portfolio_cache(str(user.id))
     return _pos_to_dict(pos)
 
 
-@router.delete("/positions/{position_id}", status_code=204)
+@router.put("/positions/{position_id}")
 @limiter.limit("30/minute")
-async def delete_position(request: Request, position_id: uuid.UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def update_position(request: Request, position_id: uuid.UUID, data: PositionUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    return await update_position_core(db, user, position_id, data)
+
+
+async def delete_position_core(
+    db: AsyncSession,
+    user: User,
+    position_id: uuid.UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen einer Position — geteilt mit der externen API."""
     pos = await db.get(Position, position_id)
     if not pos or pos.user_id != user.id:
         raise HTTPException(status_code=404, detail="Position nicht gefunden")
     user_id = pos.user_id
     created = pos.created_at.date() if pos.created_at else None
+    if audit_log is not None:
+        audit_log.ticker = (pos.ticker or "")[:30]
+        audit_log.target_id = pos.id
+        db.add(audit_log)
     await db.delete(pos)
     await db.commit()
     invalidate_portfolio_cache(str(user.id))
     trigger_snapshot_regen(user_id, created)
+
+
+@router.delete("/positions/{position_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_position(request: Request, position_id: uuid.UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    await delete_position_core(db, user, position_id)
 
 
 @router.get("/positions/{position_id}/dividends")

--- a/backend/api/precious_metals.py
+++ b/backend/api/precious_metals.py
@@ -19,6 +19,7 @@ from models.precious_metal_item import PreciousMetalItem
 from models.precious_metal_expense import PreciousMetalExpense, PreciousMetalExpenseCategory
 from models.property import Frequency
 from models.user import User
+from models.api_write_log import ApiWriteLog
 
 router = APIRouter(prefix="/api/precious-metals", tags=["precious-metals"])
 
@@ -122,6 +123,270 @@ def _annual_cost(exp: PreciousMetalExpense) -> float:
     return amount
 
 
+# ---------------------------------------------------------------------------
+# Core-Funktionen — geteilt zwischen internem UI-Endpoint und externer API
+# ---------------------------------------------------------------------------
+
+
+async def create_metal_item_core(
+    db: AsyncSession,
+    user: User,
+    data: PreciousMetalCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen eines Edelmetall-Eintrags.
+
+    Bei gesetztem ``audit_log`` wird dieser atomar mit dem Eintrag
+    committet (target_id nach flush gesetzt).
+    """
+    # Enum-Validierung
+    if data.metal_type not in ("gold", "silver", "platinum", "palladium"):
+        raise HTTPException(422, "Ungültiger Metall-Typ")
+    if data.form not in ("bar", "coin", "other"):
+        raise HTTPException(422, "Ungültige Form")
+    if data.weight_grams <= 0:
+        raise HTTPException(422, "Gewicht muss positiv sein")
+
+    # Per-user Limit prüfen
+    count_result = await db.execute(
+        select(func.count()).select_from(PreciousMetalItem).where(PreciousMetalItem.user_id == user.id)
+    )
+    if (count_result.scalar() or 0) >= MAX_PRECIOUS_METAL_ITEMS_PER_USER:
+        raise HTTPException(400, f"Limit erreicht (max. {MAX_PRECIOUS_METAL_ITEMS_PER_USER} Edelmetall-Einträge)")
+
+    item = PreciousMetalItem(
+        user_id=user.id,
+        metal_type=data.metal_type,
+        form=data.form,
+        manufacturer=data.manufacturer,
+        weight_grams=data.weight_grams,
+        serial_number=encrypt_field(data.serial_number),
+        fineness=data.fineness or "999.9",
+        purchase_date=data.purchase_date,
+        purchase_price_chf=data.purchase_price_chf,
+        storage_location=encrypt_field(data.storage_location),
+        notes=encrypt_field(data.notes),
+    )
+    db.add(item)
+    await db.flush()
+    await sync_metal_position(db, user.id, data.metal_type)
+
+    # Audit-Log atomar mit dem Eintrag committen
+    if audit_log is not None:
+        audit_log.ticker = (data.metal_type or "")[:30]
+        audit_log.target_id = item.id
+        db.add(audit_log)
+
+    await db.commit()
+    await db.refresh(item)
+    invalidate_portfolio_cache(str(user.id))
+    trigger_snapshot_regen(user.id, data.purchase_date)
+    return _item_to_dict(item)
+
+
+async def update_metal_item_core(
+    db: AsyncSession,
+    user: User,
+    item_id: uuid.UUID,
+    data: PreciousMetalUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aktualisieren eines Edelmetall-Eintrags."""
+    item = await db.get(PreciousMetalItem, item_id)
+    if not item or item.user_id != user.id:
+        raise HTTPException(404, "Nicht gefunden")
+
+    updates = data.model_dump(exclude_unset=True)
+    # PII-Felder verschlüsseln
+    for field in ("serial_number", "storage_location", "notes"):
+        if field in updates:
+            updates[field] = encrypt_field(updates[field]) if updates[field] else None
+
+    for key, val in updates.items():
+        setattr(item, key, val)
+
+    # Audit-Log atomar setzen bevor flush/commit
+    if audit_log is not None:
+        audit_log.ticker = (item.metal_type or "")[:30]
+        audit_log.target_id = item.id
+        db.add(audit_log)
+
+    await db.flush()
+    await sync_metal_position(db, user.id, item.metal_type)
+    await db.commit()
+    await db.refresh(item)
+    invalidate_portfolio_cache(str(user.id))
+    trigger_snapshot_regen(user.id, item.purchase_date)
+    return _item_to_dict(item)
+
+
+async def delete_metal_item_core(
+    db: AsyncSession,
+    user: User,
+    item_id: uuid.UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen eines Edelmetall-Eintrags."""
+    item = await db.get(PreciousMetalItem, item_id)
+    if not item or item.user_id != user.id:
+        raise HTTPException(404, "Nicht gefunden")
+
+    # Werte vor dem Loeschen sichern (nach delete/flush nicht mehr lesbar)
+    metal_type = item.metal_type
+    purchase_date = item.purchase_date
+
+    # Audit-Log atomar mit dem Loeschen committen
+    if audit_log is not None:
+        audit_log.ticker = (metal_type or "")[:30]
+        audit_log.target_id = item.id
+        db.add(audit_log)
+
+    await db.delete(item)
+    await db.flush()
+    await sync_metal_position(db, user.id, metal_type)
+    await db.commit()
+    invalidate_portfolio_cache(str(user.id))
+    trigger_snapshot_regen(user.id, purchase_date)
+
+
+async def create_metal_expense_core(
+    db: AsyncSession,
+    user: User,
+    data: ExpenseCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen einer Edelmetall-Ausgabe.
+
+    Bei gesetztem ``audit_log`` wird dieser atomar mit der Ausgabe
+    committet (target_id nach flush gesetzt).
+    """
+    # Enum-Validierung
+    try:
+        category = PreciousMetalExpenseCategory(data.category)
+    except ValueError:
+        raise HTTPException(422, "Ungültige Kategorie")
+
+    frequency = None
+    if data.recurring:
+        if not data.frequency:
+            raise HTTPException(422, "Frequenz ist bei wiederkehrenden Ausgaben erforderlich")
+        try:
+            frequency = Frequency(data.frequency)
+        except ValueError:
+            raise HTTPException(422, "Ungültige Frequenz")
+
+    if data.metal_type and data.metal_type not in ("gold", "silver", "platinum", "palladium"):
+        raise HTTPException(422, "Ungültige Metallart")
+
+    # Per-user Limit prüfen
+    count_result = await db.execute(
+        select(func.count()).select_from(PreciousMetalExpense).where(PreciousMetalExpense.user_id == user.id)
+    )
+    if (count_result.scalar() or 0) >= MAX_PRECIOUS_METAL_EXPENSES_PER_USER:
+        raise HTTPException(
+            400,
+            f"Limit erreicht (max. {MAX_PRECIOUS_METAL_EXPENSES_PER_USER} Edelmetall-Ausgaben)",
+        )
+
+    exp = PreciousMetalExpense(
+        user_id=user.id,
+        metal_type=data.metal_type,
+        date=data.date,
+        category=category,
+        description=data.description,
+        amount=data.amount,
+        recurring=data.recurring,
+        frequency=frequency,
+    )
+    db.add(exp)
+    await db.flush()
+
+    # Audit-Log atomar mit der Ausgabe committen
+    if audit_log is not None:
+        audit_log.ticker = (data.metal_type or "expense")[:30]
+        audit_log.target_id = exp.id
+        db.add(audit_log)
+
+    await db.commit()
+    await db.refresh(exp)
+    return _expense_to_dict(exp)
+
+
+async def update_metal_expense_core(
+    db: AsyncSession,
+    user: User,
+    expense_id: uuid.UUID,
+    data: ExpenseUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aktualisieren einer Edelmetall-Ausgabe."""
+    exp = await db.get(PreciousMetalExpense, expense_id)
+    if not exp or exp.user_id != user.id:
+        raise HTTPException(404, "Nicht gefunden")
+
+    updates = data.model_dump(exclude_unset=True)
+    if "category" in updates and updates["category"] is not None:
+        try:
+            updates["category"] = PreciousMetalExpenseCategory(updates["category"])
+        except ValueError:
+            raise HTTPException(422, "Ungültige Kategorie")
+    if "frequency" in updates:
+        if updates["frequency"]:
+            try:
+                updates["frequency"] = Frequency(updates["frequency"])
+            except ValueError:
+                raise HTTPException(422, "Ungültige Frequenz")
+        else:
+            updates["frequency"] = None
+    if "metal_type" in updates and updates["metal_type"] and updates["metal_type"] not in ("gold", "silver", "platinum", "palladium"):
+        raise HTTPException(422, "Ungültige Metallart")
+
+    for key, val in updates.items():
+        setattr(exp, key, val)
+
+    # Audit-Log atomar setzen
+    if audit_log is not None:
+        audit_log.ticker = (exp.metal_type or "expense")[:30]
+        audit_log.target_id = exp.id
+        db.add(audit_log)
+
+    await db.commit()
+    await db.refresh(exp)
+    return _expense_to_dict(exp)
+
+
+async def delete_metal_expense_core(
+    db: AsyncSession,
+    user: User,
+    expense_id: uuid.UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen einer Edelmetall-Ausgabe."""
+    exp = await db.get(PreciousMetalExpense, expense_id)
+    if not exp or exp.user_id != user.id:
+        raise HTTPException(404, "Nicht gefunden")
+
+    # Audit-Log atomar mit dem Loeschen committen
+    if audit_log is not None:
+        audit_log.ticker = (exp.metal_type or "expense")[:30]
+        audit_log.target_id = exp.id
+        db.add(audit_log)
+
+    await db.delete(exp)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Read-only Endpoints (unveraendert)
+# ---------------------------------------------------------------------------
+
+
 @router.get("/expenses")
 async def list_expenses(
     metal_type: Optional[str] = None,
@@ -161,6 +426,11 @@ async def expenses_summary(
     }
 
 
+# ---------------------------------------------------------------------------
+# Mutierende Endpoints — duenne Wrapper um die Core-Funktionen
+# ---------------------------------------------------------------------------
+
+
 @router.post("/expenses", status_code=201)
 @limiter.limit("30/minute")
 async def create_expense(
@@ -170,44 +440,7 @@ async def create_expense(
     user: User = Depends(get_current_user),
 ):
     """Create a new precious metal expense."""
-    try:
-        category = PreciousMetalExpenseCategory(data.category)
-    except ValueError:
-        raise HTTPException(422, "Ungültige Kategorie")
-    frequency = None
-    if data.recurring:
-        if not data.frequency:
-            raise HTTPException(422, "Frequenz ist bei wiederkehrenden Ausgaben erforderlich")
-        try:
-            frequency = Frequency(data.frequency)
-        except ValueError:
-            raise HTTPException(422, "Ungültige Frequenz")
-    if data.metal_type and data.metal_type not in ("gold", "silver", "platinum", "palladium"):
-        raise HTTPException(422, "Ungültige Metallart")
-
-    count_result = await db.execute(
-        select(func.count()).select_from(PreciousMetalExpense).where(PreciousMetalExpense.user_id == user.id)
-    )
-    if (count_result.scalar() or 0) >= MAX_PRECIOUS_METAL_EXPENSES_PER_USER:
-        raise HTTPException(
-            400,
-            f"Limit erreicht (max. {MAX_PRECIOUS_METAL_EXPENSES_PER_USER} Edelmetall-Ausgaben)",
-        )
-
-    exp = PreciousMetalExpense(
-        user_id=user.id,
-        metal_type=data.metal_type,
-        date=data.date,
-        category=category,
-        description=data.description,
-        amount=data.amount,
-        recurring=data.recurring,
-        frequency=frequency,
-    )
-    db.add(exp)
-    await db.commit()
-    await db.refresh(exp)
-    return _expense_to_dict(exp)
+    return await create_metal_expense_core(db, user, data)
 
 
 @router.put("/expenses/{expense_id}")
@@ -220,30 +453,7 @@ async def update_expense(
     user: User = Depends(get_current_user),
 ):
     """Update an expense."""
-    exp = await db.get(PreciousMetalExpense, expense_id)
-    if not exp or exp.user_id != user.id:
-        raise HTTPException(404, "Nicht gefunden")
-    updates = data.model_dump(exclude_unset=True)
-    if "category" in updates and updates["category"] is not None:
-        try:
-            updates["category"] = PreciousMetalExpenseCategory(updates["category"])
-        except ValueError:
-            raise HTTPException(422, "Ungültige Kategorie")
-    if "frequency" in updates:
-        if updates["frequency"]:
-            try:
-                updates["frequency"] = Frequency(updates["frequency"])
-            except ValueError:
-                raise HTTPException(422, "Ungültige Frequenz")
-        else:
-            updates["frequency"] = None
-    if "metal_type" in updates and updates["metal_type"] and updates["metal_type"] not in ("gold", "silver", "platinum", "palladium"):
-        raise HTTPException(422, "Ungültige Metallart")
-    for key, val in updates.items():
-        setattr(exp, key, val)
-    await db.commit()
-    await db.refresh(exp)
-    return _expense_to_dict(exp)
+    return await update_metal_expense_core(db, user, expense_id, data)
 
 
 @router.delete("/expenses/{expense_id}", status_code=204)
@@ -255,11 +465,7 @@ async def delete_expense(
     user: User = Depends(get_current_user),
 ):
     """Delete an expense."""
-    exp = await db.get(PreciousMetalExpense, expense_id)
-    if not exp or exp.user_id != user.id:
-        raise HTTPException(404, "Nicht gefunden")
-    await db.delete(exp)
-    await db.commit()
+    await delete_metal_expense_core(db, user, expense_id)
 
 
 @router.get("")
@@ -302,82 +508,39 @@ async def list_items(db: AsyncSession = Depends(get_db), user: User = Depends(ge
 
 @router.post("", status_code=201)
 @limiter.limit("30/minute")
-async def create_item(request: Request, data: PreciousMetalCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def create_item(
+    request: Request,
+    data: PreciousMetalCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
     """Create a new precious metal item."""
-    if data.metal_type not in ("gold", "silver", "platinum", "palladium"):
-        raise HTTPException(422, "Ungültiger Metall-Typ")
-    if data.form not in ("bar", "coin", "other"):
-        raise HTTPException(422, "Ungültige Form")
-    if data.weight_grams <= 0:
-        raise HTTPException(422, "Gewicht muss positiv sein")
-
-    # Per-user limit
-    count_result = await db.execute(
-        select(func.count()).select_from(PreciousMetalItem).where(PreciousMetalItem.user_id == user.id)
-    )
-    if (count_result.scalar() or 0) >= MAX_PRECIOUS_METAL_ITEMS_PER_USER:
-        raise HTTPException(400, f"Limit erreicht (max. {MAX_PRECIOUS_METAL_ITEMS_PER_USER} Edelmetall-Einträge)")
-
-    item = PreciousMetalItem(
-        user_id=user.id,
-        metal_type=data.metal_type,
-        form=data.form,
-        manufacturer=data.manufacturer,
-        weight_grams=data.weight_grams,
-        serial_number=encrypt_field(data.serial_number),
-        fineness=data.fineness or "999.9",
-        purchase_date=data.purchase_date,
-        purchase_price_chf=data.purchase_price_chf,
-        storage_location=encrypt_field(data.storage_location),
-        notes=encrypt_field(data.notes),
-    )
-    db.add(item)
-    await db.flush()
-    await sync_metal_position(db, user.id, data.metal_type)
-    await db.commit()
-    await db.refresh(item)
-    invalidate_portfolio_cache(str(user.id))
-    trigger_snapshot_regen(user.id, data.purchase_date)
-    return _item_to_dict(item)
+    return await create_metal_item_core(db, user, data)
 
 
 @router.put("/{item_id}")
 @limiter.limit("30/minute")
-async def update_item(request: Request, item_id: uuid.UUID, data: PreciousMetalUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def update_item(
+    request: Request,
+    item_id: uuid.UUID,
+    data: PreciousMetalUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
     """Update a precious metal item."""
-    item = await db.get(PreciousMetalItem, item_id)
-    if not item or item.user_id != user.id:
-        raise HTTPException(404, "Nicht gefunden")
-    updates = data.model_dump(exclude_unset=True)
-    # Encrypt PII fields before saving
-    for field in ("serial_number", "storage_location", "notes"):
-        if field in updates:
-            updates[field] = encrypt_field(updates[field]) if updates[field] else None
-    for key, val in updates.items():
-        setattr(item, key, val)
-    await db.flush()
-    await sync_metal_position(db, user.id, item.metal_type)
-    await db.commit()
-    await db.refresh(item)
-    invalidate_portfolio_cache(str(user.id))
-    trigger_snapshot_regen(user.id, item.purchase_date)
-    return _item_to_dict(item)
+    return await update_metal_item_core(db, user, item_id, data)
 
 
 @router.delete("/{item_id}", status_code=204)
 @limiter.limit("30/minute")
-async def delete_item(request: Request, item_id: uuid.UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def delete_item(
+    request: Request,
+    item_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
     """Delete a precious metal item."""
-    item = await db.get(PreciousMetalItem, item_id)
-    if not item or item.user_id != user.id:
-        raise HTTPException(404, "Nicht gefunden")
-    metal_type = item.metal_type
-    await db.delete(item)
-    await db.flush()
-    await sync_metal_position(db, user.id, metal_type)
-    await db.commit()
-    invalidate_portfolio_cache(str(user.id))
-    trigger_snapshot_regen(user.id, item.purchase_date)
+    await delete_metal_item_core(db, user, item_id)
 
 
 @router.get("/sold")

--- a/backend/api/private_equity.py
+++ b/backend/api/private_equity.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import selectinload
 from api.auth import get_current_user, limiter
 from api.portfolio import invalidate_portfolio_cache
 from db import get_db
+from models.api_write_log import ApiWriteLog
 from models.private_equity import PrivateEquityHolding, PrivateEquityValuation, PrivateEquityDividend
 from models.user import User
 from services.encryption_helpers import encrypt_field
@@ -110,11 +111,16 @@ async def list_holdings(db: AsyncSession = Depends(get_db), user: User = Depends
     return await get_holdings_summary(db, user.id)
 
 
-@router.post("", status_code=201)
-@limiter.limit("30/minute")
-async def create_holding(request: Request, data: HoldingCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Create a new PE holding."""
-    # Per-user limit
+async def create_holding_core(
+    db: AsyncSession,
+    user: User,
+    data: HoldingCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen einer PE-Beteiligung — geteilt zwischen
+    internem UI-Endpoint und externer API. Bei gesetztem ``audit_log`` wird
+    dieser atomar mit der Beteiligung committet (target_id nach dem Flush)."""
     from sqlalchemy import func
     count_result = await db.execute(
         select(func.count()).select_from(PrivateEquityHolding).where(
@@ -139,12 +145,23 @@ async def create_holding(request: Request, data: HoldingCreate, db: AsyncSession
     db.add(holding)
     await db.flush()
 
+    if audit_log is not None:
+        audit_log.target_id = holding.id
+        db.add(audit_log)
+
     await sync_position(db, user.id, holding)
     await db.commit()
 
     invalidate_portfolio_cache(str(user.id))
 
     return await get_holding_detail(db, user.id, holding.id)
+
+
+@router.post("", status_code=201)
+@limiter.limit("30/minute")
+async def create_holding(request: Request, data: HoldingCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Create a new PE holding."""
+    return await create_holding_core(db, user, data)
 
 
 @router.get("/{holding_id}")
@@ -156,10 +173,16 @@ async def get_holding(holding_id: UUID, db: AsyncSession = Depends(get_db), user
     return detail
 
 
-@router.put("/{holding_id}")
-@limiter.limit("30/minute")
-async def update_holding(request: Request, holding_id: UUID, data: HoldingUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Update a PE holding."""
+async def update_holding_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    data: HoldingUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aktualisieren einer PE-Beteiligung — geteilt mit
+    der externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     if data.company_name is not None:
@@ -181,6 +204,10 @@ async def update_holding(request: Request, holding_id: UUID, data: HoldingUpdate
     if data.notes is not None:
         h.notes = encrypt_field(data.notes)
 
+    if audit_log is not None:
+        audit_log.target_id = h.id
+        db.add(audit_log)
+
     await sync_position(db, user.id, h)
     await db.commit()
 
@@ -189,13 +216,29 @@ async def update_holding(request: Request, holding_id: UUID, data: HoldingUpdate
     return await get_holding_detail(db, user.id, holding_id)
 
 
-@router.delete("/{holding_id}", status_code=204)
+@router.put("/{holding_id}")
 @limiter.limit("30/minute")
-async def delete_holding(request: Request, holding_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Delete a PE holding (CASCADE to valuations and dividends)."""
+async def update_holding(request: Request, holding_id: UUID, data: HoldingUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Update a PE holding."""
+    return await update_holding_core(db, user, holding_id, data)
+
+
+async def delete_holding_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen einer PE-Beteiligung — geteilt mit der
+    externen API."""
     h = await _get_holding(db, user.id, holding_id)
     h.is_active = False
     await sync_position(db, user.id, h)
+
+    if audit_log is not None:
+        audit_log.target_id = h.id
+        db.add(audit_log)
 
     await db.delete(h)
     await db.commit()
@@ -203,12 +246,24 @@ async def delete_holding(request: Request, holding_id: UUID, db: AsyncSession = 
     invalidate_portfolio_cache(str(user.id))
 
 
+@router.delete("/{holding_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_holding(request: Request, holding_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Delete a PE holding (CASCADE to valuations and dividends)."""
+    await delete_holding_core(db, user, holding_id)
+
+
 # --- Valuations CRUD ---
 
-@router.post("/{holding_id}/valuations", status_code=201)
-@limiter.limit("30/minute")
-async def create_valuation(request: Request, holding_id: UUID, data: ValuationCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Add a valuation to a PE holding."""
+async def create_valuation_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    data: ValuationCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen einer Bewertung — geteilt mit der externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     if len(h.valuations) >= MAX_PE_VALUATIONS_PER_HOLDING:
@@ -228,6 +283,10 @@ async def create_valuation(request: Request, holding_id: UUID, data: ValuationCr
     db.add(v)
     await db.flush()
 
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
+
     # Re-load to get updated valuation list for position sync
     h = await _get_holding(db, user.id, holding_id)
     await sync_position(db, user.id, h)
@@ -238,10 +297,24 @@ async def create_valuation(request: Request, holding_id: UUID, data: ValuationCr
     return await get_holding_detail(db, user.id, holding_id)
 
 
-@router.put("/{holding_id}/valuations/{valuation_id}")
+@router.post("/{holding_id}/valuations", status_code=201)
 @limiter.limit("30/minute")
-async def update_valuation(request: Request, holding_id: UUID, valuation_id: UUID, data: ValuationUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Update a valuation."""
+async def create_valuation(request: Request, holding_id: UUID, data: ValuationCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Add a valuation to a PE holding."""
+    return await create_valuation_core(db, user, holding_id, data)
+
+
+async def update_valuation_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    valuation_id: UUID,
+    data: ValuationUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aktualisieren einer Bewertung — geteilt mit der
+    externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     v = next((v for v in h.valuations if v.id == valuation_id), None)
@@ -259,8 +332,12 @@ async def update_valuation(request: Request, holding_id: UUID, valuation_id: UUI
     if data.notes is not None:
         v.notes = encrypt_field(data.notes)
 
-    # Recalculate net value
+    # Nettowert neu berechnen
     v.net_value_per_share = round(float(v.gross_value_per_share) * (1 - float(v.discount_pct) / 100), 2)
+
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
 
     h = await _get_holding(db, user.id, holding_id)
     await sync_position(db, user.id, h)
@@ -271,15 +348,31 @@ async def update_valuation(request: Request, holding_id: UUID, valuation_id: UUI
     return await get_holding_detail(db, user.id, holding_id)
 
 
-@router.delete("/{holding_id}/valuations/{valuation_id}", status_code=204)
+@router.put("/{holding_id}/valuations/{valuation_id}")
 @limiter.limit("30/minute")
-async def delete_valuation(request: Request, holding_id: UUID, valuation_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Delete a valuation."""
+async def update_valuation(request: Request, holding_id: UUID, valuation_id: UUID, data: ValuationUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Update a valuation."""
+    return await update_valuation_core(db, user, holding_id, valuation_id, data)
+
+
+async def delete_valuation_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    valuation_id: UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen einer Bewertung — geteilt mit der externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     v = next((v for v in h.valuations if v.id == valuation_id), None)
     if not v:
         raise HTTPException(404, "Bewertung nicht gefunden")
+
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
 
     await db.delete(v)
     await db.flush()
@@ -291,12 +384,24 @@ async def delete_valuation(request: Request, holding_id: UUID, valuation_id: UUI
     invalidate_portfolio_cache(str(user.id))
 
 
+@router.delete("/{holding_id}/valuations/{valuation_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_valuation(request: Request, holding_id: UUID, valuation_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Delete a valuation."""
+    await delete_valuation_core(db, user, holding_id, valuation_id)
+
+
 # --- Dividends CRUD ---
 
-@router.post("/{holding_id}/dividends", status_code=201)
-@limiter.limit("30/minute")
-async def create_dividend(request: Request, holding_id: UUID, data: DividendCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Add a dividend to a PE holding."""
+async def create_dividend_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    data: DividendCreate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Anlegen einer Dividende — geteilt mit der externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     if len(h.dividends) >= MAX_PE_DIVIDENDS_PER_HOLDING:
@@ -318,6 +423,11 @@ async def create_dividend(request: Request, holding_id: UUID, data: DividendCrea
         notes=encrypt_field(data.notes),
     )
     db.add(d)
+
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
+
     await db.commit()
 
     invalidate_portfolio_cache(str(user.id))
@@ -325,10 +435,24 @@ async def create_dividend(request: Request, holding_id: UUID, data: DividendCrea
     return await get_holding_detail(db, user.id, holding_id)
 
 
-@router.put("/{holding_id}/dividends/{dividend_id}")
+@router.post("/{holding_id}/dividends", status_code=201)
 @limiter.limit("30/minute")
-async def update_dividend(request: Request, holding_id: UUID, dividend_id: UUID, data: DividendUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Update a dividend."""
+async def create_dividend(request: Request, holding_id: UUID, data: DividendCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Add a dividend to a PE holding."""
+    return await create_dividend_core(db, user, holding_id, data)
+
+
+async def update_dividend_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    dividend_id: UUID,
+    data: DividendUpdate,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> dict:
+    """Kernlogik fuer das Aktualisieren einer Dividende — geteilt mit der
+    externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     d = next((d for d in h.dividends if d.id == dividend_id), None)
@@ -346,10 +470,14 @@ async def update_dividend(request: Request, holding_id: UUID, dividend_id: UUID,
     if data.notes is not None:
         d.notes = encrypt_field(data.notes)
 
-    # Recalculate amounts
+    # Betraege neu berechnen
     d.gross_amount = round(float(d.dividend_per_share) * h.num_shares, 2)
     d.withholding_tax_amount = round(float(d.gross_amount) * float(d.withholding_tax_pct) / 100, 2)
     d.net_amount = round(float(d.gross_amount) - float(d.withholding_tax_amount), 2)
+
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
 
     await db.commit()
 
@@ -358,17 +486,40 @@ async def update_dividend(request: Request, holding_id: UUID, dividend_id: UUID,
     return await get_holding_detail(db, user.id, holding_id)
 
 
-@router.delete("/{holding_id}/dividends/{dividend_id}", status_code=204)
+@router.put("/{holding_id}/dividends/{dividend_id}")
 @limiter.limit("30/minute")
-async def delete_dividend(request: Request, holding_id: UUID, dividend_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
-    """Delete a dividend."""
+async def update_dividend(request: Request, holding_id: UUID, dividend_id: UUID, data: DividendUpdate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Update a dividend."""
+    return await update_dividend_core(db, user, holding_id, dividend_id, data)
+
+
+async def delete_dividend_core(
+    db: AsyncSession,
+    user: User,
+    holding_id: UUID,
+    dividend_id: UUID,
+    *,
+    audit_log: ApiWriteLog | None = None,
+) -> None:
+    """Kernlogik fuer das Loeschen einer Dividende — geteilt mit der externen API."""
     h = await _get_holding(db, user.id, holding_id)
 
     d = next((d for d in h.dividends if d.id == dividend_id), None)
     if not d:
         raise HTTPException(404, "Dividende nicht gefunden")
 
+    if audit_log is not None:
+        audit_log.target_id = holding_id
+        db.add(audit_log)
+
     await db.delete(d)
     await db.commit()
 
     invalidate_portfolio_cache(str(user.id))
+
+
+@router.delete("/{holding_id}/dividends/{dividend_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_dividend(request: Request, holding_id: UUID, dividend_id: UUID, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    """Delete a dividend."""
+    await delete_dividend_core(db, user, holding_id, dividend_id)

--- a/backend/tests/test_external_ui_parity.py
+++ b/backend/tests/test_external_ui_parity.py
@@ -1,0 +1,195 @@
+"""Tests fuer die UI-Paritaet der externen API (v0.45).
+
+Deckt die neuen Schreib-Endpoints ab, die das interne UI 1:1 spiegeln:
+Positionen, Immobilien, Private Equity, Edelmetalle, Buckets, Performance-
+Aktionen, Settings/Onboarding sowie Scope-Enforcement quer ueber alle Domaenen.
+
+Hinweis: die Test-DB baut via create_all (nicht Alembic), daher sind die
+``api_write_log``-CHECK-Constraints hier unsichtbar (siehe Memory) — die
+Whitelist-Vollstaendigkeit wird durch Migration 085 + manuelle Verifikation
+gegen die echte DB abgesichert, nicht hier.
+"""
+
+from datetime import date
+
+import pytest
+from sqlalchemy import func, select
+
+pytestmark = pytest.mark.asyncio
+
+TEST_PASSWORD = "TestPassw0rd!2026"
+
+
+async def register_and_login(client, email: str) -> str:
+    await client.post("/api/auth/register", json={"email": email, "password": TEST_PASSWORD})
+    res = await client.post("/api/auth/login", json={"email": email, "password": TEST_PASSWORD})
+    return res.json()["access_token"]
+
+
+def jwt_auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def api_auth(api_key: str) -> dict:
+    return {"X-API-Key": api_key}
+
+
+async def make_token(client, jwt, name="t", write=False) -> str:
+    res = await client.post(
+        "/api/settings/api-tokens",
+        json={"name": name, "write_access": write},
+        headers=jwt_auth(jwt),
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["token"]
+
+
+async def rw_tokens(client, email):
+    """Liefert (write_token, read_token) fuer einen frischen User."""
+    jwt = await register_and_login(client, email)
+    w = await make_token(client, jwt, name="w", write=True)
+    r = await make_token(client, jwt, name="r", write=False)
+    return w, r
+
+
+class TestPositions:
+    async def test_create_update_delete_roundtrip_and_audit(self, client, db):
+        w, _ = await rw_tokens(client, "par-pos-w@example.com")
+        # cost_basis_chf=0 -> kein Snapshot-Regen, haelt den Test deterministisch.
+        payload = {"ticker": "TESTPOS", "name": "Test Position", "type": "stock",
+                   "currency": "CHF", "shares": 5, "cost_basis_chf": 0}
+        res = await client.post("/api/v1/external/positions", json=payload, headers=api_auth(w))
+        assert res.status_code == 201, res.text
+        pos = res.json()
+        assert pos["ticker"] == "TESTPOS"
+        pid = pos["id"]
+
+        upd = await client.put(f"/api/v1/external/positions/by-id/{pid}",
+                               json={"name": "Renamed"}, headers=api_auth(w))
+        assert upd.status_code == 200, upd.text
+        assert upd.json()["name"] == "Renamed"
+
+        from models.api_write_log import ApiWriteLog
+        actions = {r.action for r in (await db.execute(select(ApiWriteLog))).scalars().all()}
+        assert "position_create" in actions
+        assert "position_update" in actions
+
+        dele = await client.delete(f"/api/v1/external/positions/by-id/{pid}", headers=api_auth(w))
+        assert dele.status_code == 204
+
+    async def test_read_token_forbidden(self, client):
+        _, r = await rw_tokens(client, "par-pos-r@example.com")
+        res = await client.post("/api/v1/external/positions",
+                                json={"ticker": "X", "name": "X", "type": "stock"},
+                                headers=api_auth(r))
+        assert res.status_code == 403
+
+
+class TestRealEstate:
+    async def test_create_property_and_scope(self, client):
+        w, r = await rw_tokens(client, "par-re@example.com")
+        body = {"name": "Mehrfamilienhaus", "property_type": "mfh", "purchase_price": 1000000}
+        forbidden = await client.post("/api/v1/external/immobilien", json=body, headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.post("/api/v1/external/immobilien", json=body, headers=api_auth(w))
+        assert res.status_code == 201, res.text
+        assert res.json()["name"] == "Mehrfamilienhaus"
+
+
+class TestPrivateEquity:
+    async def test_create_holding_and_scope(self, client):
+        w, r = await rw_tokens(client, "par-pe@example.com")
+        body = {"company_name": "Acme AG", "num_shares": 100, "nominal_value": 100.0,
+                "currency": "CHF"}
+        forbidden = await client.post("/api/v1/external/private-equity", json=body, headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.post("/api/v1/external/private-equity", json=body, headers=api_auth(w))
+        assert res.status_code == 201, res.text
+        assert res.json()["company_name"] == "Acme AG"
+
+
+class TestPreciousMetals:
+    async def test_create_item_and_scope(self, client):
+        w, r = await rw_tokens(client, "par-pm@example.com")
+        body = {"metal_type": "gold", "form": "bar", "weight_grams": 100.0,
+                "purchase_date": date.today().isoformat(), "purchase_price_chf": 6000.0}
+        forbidden = await client.post("/api/v1/external/precious-metals", json=body, headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.post("/api/v1/external/precious-metals", json=body, headers=api_auth(w))
+        assert res.status_code == 201, res.text
+        assert res.json()["metal_type"] == "gold"
+
+
+class TestBuckets:
+    async def test_create_bucket_and_scope(self, client):
+        w, r = await rw_tokens(client, "par-bucket@example.com")
+        body = {"name": "Wachstum"}
+        forbidden = await client.post("/api/v1/external/buckets", json=body, headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.post("/api/v1/external/buckets", json=body, headers=api_auth(w))
+        assert res.status_code == 201, res.text
+        assert res.json()["name"] == "Wachstum"
+
+
+class TestPerformanceActions:
+    async def test_recalculate_scope_and_ok(self, client):
+        w, r = await rw_tokens(client, "par-perf@example.com")
+        forbidden = await client.post("/api/v1/external/performance/recalculate", headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.post("/api/v1/external/performance/recalculate", headers=api_auth(w))
+        assert res.status_code == 200, res.text
+        assert "recalculated" in res.json()
+
+
+class TestSettingsOnboarding:
+    async def test_settings_patch_scope_and_ok(self, client):
+        w, r = await rw_tokens(client, "par-settings@example.com")
+        forbidden = await client.patch("/api/v1/external/settings",
+                                       json={"base_currency": "CHF"}, headers=api_auth(r))
+        assert forbidden.status_code == 403
+        res = await client.patch("/api/v1/external/settings",
+                                 json={"base_currency": "CHF"}, headers=api_auth(w))
+        assert res.status_code == 200, res.text
+
+    async def test_settings_never_exposes_secrets(self, client):
+        w, _ = await rw_tokens(client, "par-settings-sec@example.com")
+        res = await client.patch("/api/v1/external/settings",
+                                 json={"base_currency": "CHF"}, headers=api_auth(w))
+        assert res.status_code == 200
+        for secret in ("fred_api_key", "fmp_api_key", "finnhub_api_key"):
+            assert secret not in res.json()
+
+    async def test_onboarding_step_complete(self, client):
+        w, _ = await rw_tokens(client, "par-onb@example.com")
+        res = await client.post("/api/v1/external/settings/onboarding/step-complete",
+                                json={"step": "first_position"}, headers=api_auth(w))
+        assert res.status_code == 200, res.text
+
+
+class TestScopeSmoke:
+    """Read-Token (kein write-Scope) muss bei JEDER neuen Mutation 403 geben."""
+
+    async def test_write_endpoints_reject_read_token(self, client):
+        _, r = await rw_tokens(client, "par-smoke@example.com")
+        import uuid as _uuid
+        fake = str(_uuid.uuid4())
+        cases = [
+            ("post", "/api/v1/external/dividends/" + fake + "/confirm",
+             {"date": date.today().isoformat(), "total_chf": 10.0}),
+            ("post", "/api/v1/external/screening/scan", None),
+            ("put", "/api/v1/external/etf-sectors/SPY",
+             {"sectors": [{"sector": "Technology", "weight_pct": 100.0}]}),
+            ("patch", "/api/v1/external/eps-scanner/thresholds",
+             {"super_quarter_yoy_pct": 30.0}),
+            ("put", "/api/v1/external/analysis/resistance/AAPL",
+             {"manual_resistance": 100.0}),
+            ("post", "/api/v1/external/performance/regenerate-snapshots", None),
+            ("post", "/api/v1/external/buckets/onboarding-dismiss", None),
+            ("put", "/api/v1/external/settings/alert-preferences",
+             {"category": "stop_loss", "is_enabled": True}),
+        ]
+        for method, url, body in cases:
+            fn = getattr(client, method)
+            res = await (fn(url, json=body, headers=api_auth(r)) if body is not None
+                         else fn(url, headers=api_auth(r)))
+            assert res.status_code == 403, f"{method.upper()} {url} -> {res.status_code} (erwartet 403)"

--- a/docs/EXTERNAL_API.md
+++ b/docs/EXTERNAL_API.md
@@ -6,8 +6,14 @@ Claude-Code-Instanz, eigene Skripte, Reporting-Tools).
 - **Base URL:** `https://<deine-openfolio-instanz>/api/v1/external`
   (Beispiel: `https://openfolio.cc/api/v1/external`)
 - **Auth:** `X-API-Key: ofk_...` Header
-- **Scopes:** `read` (Default, alle Tokens) + optional `write` (Watchlist-Notizen,
-  Preis-Alarme, Pending Orders, **Stop-Loss**, **Report-Vault**)
+- **Scopes:** `read` (Default, alle Tokens) + optional `write`. Ab **v0.45** ist
+  der `write`-Scope volle UI-Paritaet: jede Funktion, die im UI moeglich ist, geht
+  auch ueber die API (Positionen, Transaktionen, Immobilien, Private Equity,
+  Edelmetalle, Buckets, Dividenden, Watchlist/Tags, Alarme, Pending Orders,
+  Stop-Loss, Resistance, ETF-Sektoren, EPS-Schwellen, Screening-Scan,
+  Performance-Aktionen, Import, Settings/Onboarding, Report-Vault). **Ausgenommen**
+  (bewusst NICHT exponiert): Secret-Writes (SMTP/ntfy/FRED/FMP/Finnhub-Keys,
+  API-Token-Erstellung), Auth/Identitaet und Admin-Funktionen.
 - **Rate-Limit:** `30/minute` pro API-Key (Backend) + `60/minute` pro IP (nginx, Burst 60)
 - **CORS:** nicht aktiv (nicht für Browser-Aufrufe gedacht)
 - **PII-Verhalten (v0.38+):** Der Token-Eigentümer darf seine eigenen Daten lesen.
@@ -198,7 +204,7 @@ ein Alarm bereits existiert.
 | GET | `/screening/latest?min_score=1` | Letzte Screening-Ergebnisse + `pipeline_health` |
 | GET | `/screening/results?min_score=1&signal_type=&sector_momentum=&page=&per_page=` | Paginiertes Screening mit Filtern |
 | GET | `/screening/ticker/{ticker}` | Screening-Resultat eines einzelnen Tickers |
-| GET | `/screening/scan/{scan_id}/progress` | Scan-Fortschritt (POST `/scan` selbst bleibt UI-only) |
+| GET | `/screening/scan/{scan_id}/progress` | Scan-Fortschritt (Polling nach `POST /screening/scan`) |
 | GET | `/screening/macro/cot` | CFTC COT Macro-Positionierung |
 | GET | `/precious-metals` | Edelmetall-Bestände, gruppiert nach Metall-Typ |
 | GET | `/precious-metals/sold` | Verkaufte Bestände |
@@ -232,17 +238,91 @@ ein Alarm bereits existiert.
 | DELETE | `/reports/{report_id}` | **Scope `write`** — Einzelnen Report **endgültig** löschen (204, kein Undo). Für reversibles Entfernen `archive` nutzen. |
 | POST | `/reports/prune` | **Scope `write`** — Reconciliation: **archiviert** Vault-Waisen einer `source` (deren `source_path` nicht in `source_paths` steht); Re-Upload reaktiviert. Antwort `{archived, kept}`. Leere Liste = bewusster No-op. |
 
+### UI-Paritaet — Schreib-Endpoints (v0.45)
+
+Alle folgenden Endpoints erfordern Scope `write` und hinterlassen einen `ApiWriteLog`-Eintrag. Sie spiegeln 1:1 das interne UI.
+
+| Method | Pfad | Beschreibung |
+|---|---|---|
+| POST | `/positions` | Position anlegen (Bucket-Auto-Zuordnung, PII-Verschluesselung, Sektor-Ableitung wie UI) |
+| PUT | `/positions/by-id/{position_id}` | Position aendern |
+| DELETE | `/positions/by-id/{position_id}` | Position loeschen (Snapshot-Regen) |
+| POST | `/positions/recalculate` | Cost-Basis aller Positionen neu rechnen |
+| POST | `/positions/by-id/{position_id}/recalculate` | Einzelne Position neu rechnen |
+| POST | `/immobilien` | Immobilie anlegen |
+| PUT | `/immobilien/{property_id}` | Immobilie aendern |
+| DELETE | `/immobilien/{property_id}` | Immobilie loeschen |
+| POST | `/immobilien/{property_id}/hypotheken` | Hypothek anlegen |
+| PUT | `/immobilien/hypotheken/{mortgage_id}` | Hypothek aendern |
+| DELETE | `/immobilien/hypotheken/{mortgage_id}` | Hypothek loeschen |
+| POST | `/immobilien/{property_id}/ausgaben` | Ausgabe anlegen |
+| PUT | `/immobilien/ausgaben/{expense_id}` | Ausgabe aendern |
+| DELETE | `/immobilien/ausgaben/{expense_id}` | Ausgabe loeschen |
+| POST | `/immobilien/{property_id}/einnahmen` | Einnahme anlegen |
+| PUT | `/immobilien/einnahmen/{income_id}` | Einnahme aendern |
+| DELETE | `/immobilien/einnahmen/{income_id}` | Einnahme loeschen |
+| POST | `/private-equity` | PE-Beteiligung anlegen |
+| PUT | `/private-equity/{holding_id}` | PE-Beteiligung aendern |
+| DELETE | `/private-equity/{holding_id}` | PE-Beteiligung loeschen |
+| POST | `/private-equity/{holding_id}/valuations` | Bewertung anlegen |
+| PUT | `/private-equity/{holding_id}/valuations/{valuation_id}` | Bewertung aendern |
+| DELETE | `/private-equity/{holding_id}/valuations/{valuation_id}` | Bewertung loeschen |
+| POST | `/private-equity/{holding_id}/dividends` | PE-Dividende anlegen |
+| PUT | `/private-equity/{holding_id}/dividends/{dividend_id}` | PE-Dividende aendern |
+| DELETE | `/private-equity/{holding_id}/dividends/{dividend_id}` | PE-Dividende loeschen |
+| POST | `/precious-metals` | Edelmetall-Bestand anlegen |
+| PUT | `/precious-metals/{item_id}` | Edelmetall-Bestand aendern |
+| DELETE | `/precious-metals/{item_id}` | Edelmetall-Bestand loeschen |
+| POST | `/precious-metals/expenses` | Edelmetall-Ausgabe anlegen |
+| PUT | `/precious-metals/expenses/{expense_id}` | Edelmetall-Ausgabe aendern |
+| DELETE | `/precious-metals/expenses/{expense_id}` | Edelmetall-Ausgabe loeschen |
+| POST | `/dividends/{pending_id}/confirm` | Pending-Dividende bestaetigen (bucht Dividenden-Transaktion) |
+| POST | `/dividends/{pending_id}/dismiss` | Pending-Dividende verwerfen |
+| POST | `/buckets` | Bucket anlegen |
+| PATCH | `/buckets/{bucket_id}` | Bucket aendern |
+| DELETE | `/buckets/{bucket_id}` | Bucket loeschen (Positionen → Liquid-Default) |
+| POST | `/buckets/from-template` | Bucket-Set aus Vorlage anlegen |
+| POST | `/buckets/migration-rollback` | Bucket-Migration zurueckrollen |
+| POST | `/buckets/import-rules` | Import-Bucket-Mapping-Regel anlegen |
+| DELETE | `/buckets/import-rules/{rule_id}` | Import-Regel loeschen |
+| POST | `/buckets/backfill-snapshots` | Bucket-Snapshots rueckwirkend backfillen |
+| POST | `/buckets/onboarding-dismiss` | Bucket-Migrations-Modal schliessen |
+| POST | `/positions/by-id/{position_id}/split-to-bucket` | Position teilweise in anderen Bucket splitten |
+| POST | `/positions/by-id/{position_id}/move-to-bucket` | Position in anderen Bucket verschieben |
+| POST | `/performance/recalculate` | Cost-Basis-Recalc + Snapshot-Regen |
+| POST | `/performance/fix-total-chf` | total_chf aus FX-Rate korrigieren |
+| POST | `/performance/regenerate-snapshots` | Alle Portfolio-Snapshots neu bauen |
+| POST | `/performance/earnings/refresh` | Earnings-Termine aktualisieren |
+| POST | `/screening/scan` | Screening-Scan starten (1/Tag; Fortschritt via `/screening/scan/{id}/progress`) |
+| PUT | `/etf-sectors/{ticker}` | ETF-Sektorgewichte setzen (Summe = 100%) |
+| DELETE | `/etf-sectors/{ticker}` | ETF-Sektorgewichte loeschen |
+| PATCH | `/eps-scanner/thresholds` | EPS-Scanner-Filterschwellen setzen |
+| PUT | `/analysis/resistance/{ticker}` | Manuelles Resistance-Level setzen (Positionen + Watchlist) |
+| POST | `/watchlist/{item_id}/tags` | Tag an Watchlist-Eintrag haengen (find-or-create, max. 5) |
+| DELETE | `/watchlist/{item_id}/tags/{tag_id}` | Tag von Watchlist-Eintrag entfernen |
+| PATCH | `/settings` | User-Einstellungen aendern (KEINE Secrets — API-Keys/SMTP/ntfy bleiben gesperrt) |
+| PUT | `/settings/alert-preferences` | Alert-Praeferenz pro Kategorie setzen |
+| POST | `/settings/onboarding/tour-complete` | Onboarding-Tour abschliessen |
+| POST | `/settings/onboarding/hide-checklist` | Onboarding-Checkliste ausblenden |
+| POST | `/settings/onboarding/step-complete` | Onboarding-Schritt erledigen |
+| POST | `/import/parse` | CSV hochladen + parsen (multipart, Vorschau) |
+| POST | `/import/analyze` | CSV-Struktur analysieren (multipart) |
+| POST | `/import/parse-with-mapping` | Hochgeladene CSV mit explizitem Mapping parsen |
+| POST | `/import/confirm` | Geparste Transaktionen bestaetigen + bulk-inserten (Recalc + Snapshot-Regen) |
+| GET | `/import/profiles` | Import-Profile auflisten |
+| POST | `/import/profiles` | Import-Profil anlegen |
+| DELETE | `/import/profiles/{profile_id}` | Import-Profil loeschen |
+
 > **Hinweis:** Immobilien (HEILIGE Regel 4) und Vorsorge (HEILIGE Regel 5)
 > haben bewusst eigene Namespaces. Sie sind **nicht** Teil der liquiden
 > Portfolio-Performance unter `/portfolio/*` und `/performance/*` und werden
 > dort niemals eingerechnet. Aggregierte Werte (`total_value_chf`, `equity`,
 > `current_mortgage`) gelten ausschliesslich innerhalb dieser Namespaces.
 >
-> **Buckets (v0.39):** Read-Only via External-API. Schreib-Endpoints
-> (`move-to-bucket`, `split-to-bucket`, Bucket-CRUD, Templates, Migration-
-> Rollback, Backfill, Import-Rules) bleiben **JWT-only** über `/api/portfolio/buckets/*`
-> — Drittparteien können analysieren, aber nicht selbständig umstrukturieren.
-> Jede Position im `/positions`-Response enthält ab v0.39 die Felder
+> **Buckets:** Lesen seit v0.39, **Schreiben seit v0.45** — Bucket-CRUD,
+> Templates, Migration-Rollback, Backfill, Import-Rules sowie `move-to-bucket`/
+> `split-to-bucket` sind jetzt mit Scope `write` ueber die External-API erreichbar
+> (siehe Tabelle oben). Jede Position im `/positions`-Response enthält die Felder
 > `bucket_id` (UUID oder `null`) und `risk_rules` (Position-Level-Override,
 > meistens `null`).
 
@@ -1951,6 +2031,30 @@ curl -X POST \
 
 Die API ist unter `/api/v1/external/*` gemounted. Breaking Changes erfolgen nur
 unter einem neuen Versions-Prefix (`/api/v2/...`); v1 bleibt stabil.
+
+### v0.45 — Volle UI-Schreib-Paritaet
+
+- **Jede UI-Funktion ist jetzt auch ueber die API erreichbar** (Scope `write`).
+  Neu hinzugekommen: Positionen-CRUD + Recalc, Immobilien (Objekte/Hypotheken/
+  Ausgaben/Einnahmen), Private Equity (Holdings/Bewertungen/Dividenden),
+  Edelmetalle (Items/Ausgaben), Pending-Dividenden confirm/dismiss, Buckets
+  (CRUD, Templates, Migration-Rollback, Import-Rules, Backfill, Split/Move),
+  Performance-Aktionen (Recalc, Fix-Total-CHF, Snapshot-Regen, Earnings-Refresh),
+  Screening-Scan, ETF-Sektorgewichte, EPS-Schwellen, Resistance, Watchlist-Tags,
+  Settings + Onboarding und der komplette Import-Flow (parse/analyze/mapping/
+  confirm/profiles). Vollstaendige Liste: Abschnitt „UI-Paritaet — Schreib-
+  Endpoints" oben.
+- **Geteilte Kernlogik** mit den internen Endpoints ueber `_core`-Funktionen
+  (`create_position_core`, `create_holding_core`, `confirm_pending_dividend_core`
+  usw.) bzw. denselben Service-Layer — kein zweiter Code-Pfad, identisches
+  Verhalten (Verschluesselung, Snapshot-Regen, Cache-Invalidierung, Auto-Anlagen).
+- **Audit-Log atomar** mit jeder Mutation committet; Migration 085 erweitert die
+  `ck_api_write_log_action`-Whitelist um alle neuen Aktionen (sonst Prod-500 +
+  Rollback).
+- **Bewusst NICHT exponiert** (Sicherheits-Entscheidung): Secret-Writes
+  (SMTP/ntfy/FRED/FMP/Finnhub-Keys, API-Token-Erstellung), Auth/Identitaet
+  (Login/MFA/Passwort/Sessions/Account-Delete) und Admin-Funktionen
+  (User-Management, Invite-Codes). Diese bleiben JWT/UI- bzw. admin-only.
 
 ### v0.42 — Transaktionen voll schreibbar (CRUD)
 


### PR DESCRIPTION
## Ziel

Jede Funktion, die im UI möglich ist, ist jetzt auch über die externe REST-API (`/api/v1/external/*`, X-API-Key) steuerbar. Damit lässt sich OpenFolio per AI/Skript 1:1 wie über das UI bedienen.

## Umfang

**88 Write-Routes** (Scope `write`, atomarer `ApiWriteLog`) über alle Domänen:
- Positionen (CRUD + Recalc)
- Immobilien (Objekte / Hypotheken / Ausgaben / Einnahmen)
- Private Equity (Holdings / Bewertungen / Dividenden)
- Edelmetalle (Items / Ausgaben)
- Pending-Dividenden (confirm / dismiss)
- Buckets (CRUD, Templates, Split/Move, Import-Rules, Backfill, Migration-Rollback)
- Performance-Aktionen (Recalc, Fix-Total-CHF, Snapshot-Regen, Earnings-Refresh)
- Screening-Scan, ETF-Sektoren, EPS-Schwellen, Resistance, Watchlist-Tags
- Settings + Onboarding (**ohne** Secrets)
- Kompletter Import-Flow (parse / analyze / mapping / confirm / profiles)

## Architektur

- Geteilte `_core(..., *, audit_log=None)`-Funktionen aus `positions.py`, `private_equity.py`, `precious_metals.py`, `dividends.py` — identisches Verhalten zum internen UI (Verschlüsselung, sync, Snapshot-Regen, Cache-Invalidierung), kein zweiter Code-Pfad.
- Whitelist-Write-Schemas + `filter_*`-Response-Helfer (PII-Vertrag v0.38, IBAN maskiert; `filter_settings` strippt Secrets).
- **Migration 085** erweitert `ck_api_write_log_action` um alle neuen Actions.

## Bewusst NICHT exponiert (Sicherheit, mit Maintainer abgestimmt)

Secret-Writes (SMTP / ntfy / FRED / FMP / Finnhub-Keys, API-Token-Erstellung), Auth/Identität, Admin-Funktionen.

## Tests & Audit

- `test_external_ui_parity.py` — Scope-Enforcement + CRUD-Roundtrips
- 129 Tests der betroffenen internen Router-Suites bleiben grün
- `@openfolio-audit` = **PASS** (`AUDIT_ui_parity_v0.45.md`); Low-Finding #1 (Import-Audit-Log vor Parse) behoben

## ⚠️ Deploy-Hinweis

**`alembic upgrade head` muss vor dem Rollout laufen** — sonst Prod-500 beim ersten Write, weil die `ApiWriteLog`-Action-Whitelist fehlt (gemeinsamer Commit rollt zurück).

🤖 Generated with [Claude Code](https://claude.com/claude-code)