### PR TITLE
chore(release): v0.46.0 — External API UI-Schreib-Parität

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ Alle wichtigen Änderungen an OpenFolio werden in dieser Datei dokumentiert.
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/)
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
+## [0.46.0] — 2026-06-24
+
+### Hinzugefügt
+
+- **Volle UI-Schreib-Paritaet der External API** — jede Funktion, die im UI
+  möglich ist, ist jetzt auch über `/api/v1/external/*` (Header `X-API-Key`,
+  Scope `write`) steuerbar. Neu schreibbar: Positionen (CRUD + Recalculate),
+  Immobilien (Objekte/Hypotheken/Ausgaben/Einnahmen), Private Equity (Holdings/
+  Bewertungen/Dividenden), Edelmetalle (Items/Ausgaben), Pending-Dividenden
+  (confirm/dismiss), Buckets (CRUD, Templates, Split/Move, Import-Rules,
+  Backfill, Migration-Rollback), Performance-Aktionen (Recalculate,
+  Fix-Total-CHF, Snapshot-Regen, Earnings-Refresh), Screening-Scan,
+  ETF-Sektorgewichte, EPS-Schwellen, Resistance, Watchlist-Tags, Settings +
+  Onboarding sowie der komplette Import-Flow (parse/analyze/mapping/confirm/
+  profiles). Geteilte Kernlogik mit dem internen UI über `_core`-Funktionen;
+  jeder Schreibvorgang hinterlässt einen atomaren `ApiWriteLog`. Doku:
+  `docs/EXTERNAL_API.md`.
+
+### Sicherheit
+
+- **Bewusst NICHT über die External API exponiert**: Secret-Writes (SMTP/ntfy/
+  FRED/FMP/Finnhub-API-Keys, API-Token-Erstellung), Auth/Identität
+  (Login/MFA/Passwort/Sessions/Account-Delete) und Admin-Funktionen
+  (User-Management, Invite-Codes) — bleiben JWT/UI- bzw. admin-only.
+
+### Migration
+
+- `alembic upgrade head` ausführen (Migration 085 erweitert die
+  `api_write_log.action`-Whitelist um alle neuen Schreib-Aktionen). Läuft beim
+  Container-Start automatisch via Entrypoint. **Ohne diese Migration schlägt der
+  erste externe Schreibzugriff mit HTTP 500 fehl** (atomarer Audit-Log-Insert
+  gegen den CHECK-Constraint rollt die Mutation zurück).
+
 ## [0.45.0] — 2026-06-23
 
 ### Hinzugefügt

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,3 +1,3 @@
 # Single source of truth for backend version.
 # Keep in sync with frontend/package.json "version" field.
-APP_VERSION = "0.45.0"
+APP_VERSION = "0.46.0"

--- a/docs/EXTERNAL_API.md
+++ b/docs/EXTERNAL_API.md
@@ -6,7 +6,7 @@ Claude-Code-Instanz, eigene Skripte, Reporting-Tools).
 - **Base URL:** `https://<deine-openfolio-instanz>/api/v1/external`
   (Beispiel: `https://openfolio.cc/api/v1/external`)
 - **Auth:** `X-API-Key: ofk_...` Header
-- **Scopes:** `read` (Default, alle Tokens) + optional `write`. Ab **v0.45** ist
+- **Scopes:** `read` (Default, alle Tokens) + optional `write`. Ab **v0.46** ist
   der `write`-Scope volle UI-Paritaet: jede Funktion, die im UI moeglich ist, geht
   auch ueber die API (Positionen, Transaktionen, Immobilien, Private Equity,
   Edelmetalle, Buckets, Dividenden, Watchlist/Tags, Alarme, Pending Orders,
@@ -238,7 +238,7 @@ ein Alarm bereits existiert.
 | DELETE | `/reports/{report_id}` | **Scope `write`** — Einzelnen Report **endgültig** löschen (204, kein Undo). Für reversibles Entfernen `archive` nutzen. |
 | POST | `/reports/prune` | **Scope `write`** — Reconciliation: **archiviert** Vault-Waisen einer `source` (deren `source_path` nicht in `source_paths` steht); Re-Upload reaktiviert. Antwort `{archived, kept}`. Leere Liste = bewusster No-op. |
 
-### UI-Paritaet — Schreib-Endpoints (v0.45)
+### UI-Paritaet — Schreib-Endpoints (v0.46)
 
 Alle folgenden Endpoints erfordern Scope `write` und hinterlassen einen `ApiWriteLog`-Eintrag. Sie spiegeln 1:1 das interne UI.
 
@@ -319,7 +319,7 @@ Alle folgenden Endpoints erfordern Scope `write` und hinterlassen einen `ApiWrit
 > dort niemals eingerechnet. Aggregierte Werte (`total_value_chf`, `equity`,
 > `current_mortgage`) gelten ausschliesslich innerhalb dieser Namespaces.
 >
-> **Buckets:** Lesen seit v0.39, **Schreiben seit v0.45** — Bucket-CRUD,
+> **Buckets:** Lesen seit v0.39, **Schreiben seit v0.46** — Bucket-CRUD,
 > Templates, Migration-Rollback, Backfill, Import-Rules sowie `move-to-bucket`/
 > `split-to-bucket` sind jetzt mit Scope `write` ueber die External-API erreichbar
 > (siehe Tabelle oben). Jede Position im `/positions`-Response enthält die Felder
@@ -2032,7 +2032,7 @@ curl -X POST \
 Die API ist unter `/api/v1/external/*` gemounted. Breaking Changes erfolgen nur
 unter einem neuen Versions-Prefix (`/api/v2/...`); v1 bleibt stabil.
 
-### v0.45 — Volle UI-Schreib-Paritaet
+### v0.46 — Volle UI-Schreib-Paritaet
 
 - **Jede UI-Funktion ist jetzt auch ueber die API erreichbar** (Scope `write`).
   Neu hinzugekommen: Positionen-CRUD + Recalc, Immobilien (Objekte/Hypotheken/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openfolio",
   "private": true,
-  "version": "0.45.0",
+  "version": "0.46.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Versions-Bump **0.45.0 → 0.46.0** für die External-API UI-Schreib-Parität (PR #4).

`v0.45.0` (Tag) war die EPS-Scanner-Release (`5d333ab`) — die UI-Parität kam danach und braucht eine eigene Minor-Version.

- `backend/version.py` + `frontend/package.json` → 0.46.0
- `CHANGELOG.md`: [0.46.0]-Sektion (Feature, Sicherheits-Ausschlüsse, Migration-085-Hinweis)
- `docs/EXTERNAL_API.md`: v0.45- → v0.46-Labels korrigiert

Tag `v0.46.0` folgt nach dem Merge auf den Merge-Commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)