### PR TITLE
feat(portfolio): T-Bill-/Geldmarkt-ETFs als Cash führen (count_as_cash) — v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Alle wichtigen Änderungen an OpenFolio werden in dieser Datei dokumentiert.
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/)
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
+## [0.47.0] — 2026-06-25
+
+### Hinzugefügt
+
+- **T-Bill-/Geldmarkt-ETFs als Cash führen** — neues Flag `count_as_cash` pro
+  Position. Eine so markierte ETF-Position bleibt eine regulär bepreiste
+  Wertschrift (Marktwert = `Anteile × Kurs × FX`, Performance und PnL
+  unverändert), wird aber als Cash klassifiziert: sie zählt in der
+  Anlageklassen-Allokation (`by_type` → `cash`), in der Cash-Quote sowie in den
+  Portfolio- und Bucket-Snapshots (`cash_chf`) und ist aus der Core/Satellite-
+  Aufteilung ausgenommen. Im Add-/Edit-Dialog erscheint bei Typ ETF eine
+  Checkbox „Als Cash zählen (Geldmarkt-/T-Bill-ETF)"; in der Portfolio-Tabelle
+  kennzeichnet ein „Cash"-Badge solche Positionen.
+- **External API in Parität**: `count_as_cash` ist über `POST /positions` und
+  `PUT /positions/by-id/{id}` (Scope `write`) setzbar und wird in jeder Position
+  des `/positions`- und `/portfolio/summary`-Response zurückgegeben. Doku:
+  `docs/EXTERNAL_API.md`.
+
+### Migration
+
+- `alembic upgrade head` ausführen (Migration 086 fügt die Spalte
+  `positions.count_as_cash` hinzu — additiv, `NOT NULL DEFAULT false`, kein
+  Backfill, kein Lock-Risiko, Downgrade vorhanden). Läuft beim Container-Start
+  automatisch via Entrypoint.
+
 ## [0.46.0] — 2026-06-24
 
 ### Hinzugefügt

--- a/HANDOVER-tbill-etf-cash-2026-06-25.md
+++ b/HANDOVER-tbill-etf-cash-2026-06-25.md
@@ -1,0 +1,102 @@
+# Handover — T-Bill-/Geldmarkt-ETFs als Cash (v0.47) Prod-Deploy
+
+**Datum:** 2026-06-25
+**Feature:** Branch `feat/tbill-etf-count-as-cash` → `main`
+**Betrifft Prod:** ja — **Migration 086 muss laufen** (läuft automatisch via Entrypoint).
+
+---
+
+## Was deployed wird
+
+Neues Flag `positions.count_as_cash`. Eine ETF-Position mit `count_as_cash = TRUE`
+bleibt eine regulär bepreiste Wertschrift — Marktwert = `Anteile × Kurs × FX`,
+Performance/PnL unverändert (HEILIGE Regel 1 unberührt) —, wird aber als **Cash**
+klassifiziert:
+
+- Anlageklassen-Allokation (`by_type` → `cash`)
+- Cash-Quote sowie Portfolio- und Bucket-Snapshots (`cash_chf`)
+- aus der Core/Satellite-Aufteilung ausgenommen
+
+UI: Checkbox „Als Cash zählen (Geldmarkt-/T-Bill-ETF)" im Add-/Edit-Dialog (nur bei
+Typ ETF) + „Cash"-Badge in der Portfolio-Tabelle. External API in Parität
+(`count_as_cash` in Create/Update-Body und in jeder Position-Response).
+
+**Migration 086** (`086_position_count_as_cash`): additives
+`ADD COLUMN count_as_cash boolean NOT NULL DEFAULT false`. Kein Backfill, kein
+Lock-Risiko, forward-only safe, Downgrade (`DROP COLUMN`) vorhanden.
+
+---
+
+## ⚠️ Migrations-Reihenfolge prüfen
+
+Falls Prod **Migration 085** (External-API-UI-Parität, v0.46) noch nicht hatte,
+zieht `alembic upgrade head` **085 und 086** in einem Rutsch. Beide sind sicher.
+Vor dem Deploy prüfen, was ansteht:
+
+```bash
+docker compose exec -T backend alembic history -r current:head
+```
+
+---
+
+## Deploy (auf 10.10.70.10, im Projekt-Root)
+
+Migration läuft **automatisch** via `backend/entrypoint.sh` (`alembic upgrade head`
+beim Containerstart). Das generische Deploy-Skript deckt alles ab:
+
+```bash
+./scripts/prod_deploy.sh
+```
+
+Ablauf: DB-Backup → `git pull origin main` → Backend-Rebuild (Migration via
+Entrypoint) → Verifikation `DB-Head == Code-Head` (Abbruch bei Mismatch) →
+Frontend/Worker-Rebuild → Health-Smoke-Test. Frontend-Rebuild ist nötig (Checkbox +
+Badge). Bei jedem Fehler: Stop + Rollback-Anleitung am Skript-Ende.
+
+---
+
+## Nachprüfung (manuell, nach dem Skript)
+
+```bash
+PG_USER=$(grep '^POSTGRES_USER=' .env | cut -d= -f2)   # prod: openfolio
+PG_DB=$(grep '^POSTGRES_DB=' .env | cut -d= -f2)        # prod: openfolio
+
+# (a) Head == 086
+docker compose exec -T backend alembic current           # erwartet: 086 (head)
+
+# (b) Spalte existiert (Beweis, dass 086 griff)
+docker compose exec -T db psql -U "$PG_USER" "$PG_DB" -tAc \
+  "SELECT 1 FROM information_schema.columns WHERE table_name='positions' AND column_name='count_as_cash';" \
+  | grep -q 1 && echo "086 OK" || echo "FEHLT — 086 nicht angewandt!"
+
+# (c) Health == 0.47.0
+curl -sf http://127.0.0.1:8000/api/health | grep -o '"version":"[^"]*"'
+```
+
+### Optional: End-to-End-Smoke-Test der API
+
+Braucht ein **write-scoped** API-Token und wegen Cloudflare einen eigenen
+User-Agent:
+
+```bash
+WRITE_KEY=ofk_...
+curl -s -X POST https://openfolio.cc/api/v1/external/positions \
+  -H "X-API-Key: $WRITE_KEY" -H "User-Agent: openfolio-deploy-check/1.0" \
+  -H "Content-Type: application/json" \
+  -d '{"ticker":"IB01.L","name":"iShares T-Bill 0-3m","type":"etf","count_as_cash":true,"shares":10,"cost_basis_chf":1000}'
+# Response muss "count_as_cash": true enthalten → danach Throwaway-Position wieder löschen.
+```
+
+---
+
+## Rollback
+
+```bash
+docker compose stop backend worker
+git reset --hard <PREV_HEAD>      # vom Skript am Ende ausgegeben
+docker compose up -d --build
+# Falls die Migration zurückgerollt werden muss:
+docker compose exec -T backend alembic downgrade -1   # DROP COLUMN count_as_cash
+```
+
+Da additiv und ohne Backfill ist das ein risikoarmer Deploy.

--- a/backend/alembic/versions/086_position_count_as_cash.py
+++ b/backend/alembic/versions/086_position_count_as_cash.py
@@ -1,0 +1,38 @@
+"""Fuege positions.count_as_cash hinzu — Geldmarkt-/T-Bill-ETFs als Cash zaehlen.
+
+Eine Position mit ``count_as_cash = TRUE`` bleibt eine echte, live-bepreiste
+Wertschrift (shares × price × fx, Performance unveraendert), wird aber in
+Allokation (by_type → "cash"), Cash-Quote, Portfolio- und Bucket-Snapshots
+(cash_chf) als Cash klassifiziert. Default FALSE — bestehende Positionen
+bleiben unveraendert.
+
+Revision ID: 086
+Revises: 085
+Create Date: 2026-06-25
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "086"
+down_revision: Union[str, None] = "085"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "positions",
+        sa.Column(
+            "count_as_cash",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("positions", "count_as_cash")

--- a/backend/api/external_v1_schemas.py
+++ b/backend/api/external_v1_schemas.py
@@ -122,7 +122,7 @@ EXTERNAL_POSITION_FIELDS = {
     "shares", "cost_basis_chf", "market_value_chf", "current_price",
     "price_currency", "pnl_chf", "pnl_pct", "weight_pct",
     "style", "mansfield_rs", "ma_status", "ma_detail",
-    "buy_date", "is_etf", "is_stale",
+    "buy_date", "is_etf", "count_as_cash", "is_stale",
     # PII / Konto-Metadaten (v0.38: Token-Eigentümer darf eigene Daten lesen)
     "bank_name", "iban", "notes",
     # Stop-Loss-Felder
@@ -505,6 +505,7 @@ class ExternalPositionCreate(_StrictWrite):
     shares: float = Field(default=0, ge=0)
     cost_basis_chf: float = Field(default=0, ge=0)
     current_price: Optional[float] = Field(default=None, ge=0)
+    count_as_cash: bool = False
     notes: Optional[str] = Field(default=None, max_length=2000)
     bank_name: Optional[str] = Field(default=None, max_length=200)
     iban: Optional[str] = Field(default=None, max_length=34)
@@ -530,6 +531,7 @@ class ExternalPositionUpdate(_StrictWrite):
     shares: Optional[float] = Field(default=None, ge=0)
     cost_basis_chf: Optional[float] = Field(default=None, ge=0)
     current_price: Optional[float] = Field(default=None, ge=0)
+    count_as_cash: Optional[bool] = None
     manual_resistance: Optional[float] = Field(default=None, ge=0)
     is_active: Optional[bool] = None
     bank_name: Optional[str] = Field(default=None, max_length=200)

--- a/backend/api/positions.py
+++ b/backend/api/positions.py
@@ -178,6 +178,11 @@ async def create_position_core(
     from models.bucket import Bucket, BucketSystemRole, BucketKind
     asset_type = dump.get("type")
     type_value = asset_type.value if hasattr(asset_type, "value") else asset_type
+    # count_as_cash ist nur fuer ETFs sinnvoll (Geldmarkt-/T-Bill-ETF). Fuer alle
+    # anderen Typen hart auf False klemmen — verhindert sinnlose Cash-Reklassifikation
+    # eines Stocks/Krypto via API.
+    if type_value != "etf":
+        dump["count_as_cash"] = False
     role_map = {
         "real_estate": BucketSystemRole.real_estate,
         "private_equity": BucketSystemRole.private_equity,
@@ -291,6 +296,13 @@ async def update_position_core(
         else:
             # Industry cleared → clear sector too
             updates["sector"] = None
+    # count_as_cash nur fuer ETFs — bei nicht-ETF (auch bei Typwechsel weg von
+    # ETF) hart auf False klemmen, damit keine stale-true-Reklassifikation bleibt.
+    if "count_as_cash" in updates or "type" in updates:
+        eff_type = updates.get("type", pos.type)
+        eff_type_val = eff_type.value if hasattr(eff_type, "value") else eff_type
+        if eff_type_val != "etf":
+            updates["count_as_cash"] = False
     for key, val in updates.items():
         setattr(pos, key, val)
     # Stop-Loss-Aenderungen muessen die Review-Uhr zuruecksetzen — sonst

--- a/backend/api/positions.py
+++ b/backend/api/positions.py
@@ -49,6 +49,7 @@ class PositionCreate(BaseModel):
     shares: float = Field(default=0, ge=0)
     cost_basis_chf: float = Field(default=0, ge=0)
     current_price: Optional[float] = Field(default=None, ge=0)
+    count_as_cash: bool = False
     notes: Optional[str] = Field(default=None, max_length=2000)
     bank_name: Optional[str] = Field(default=None, max_length=200)
     iban: Optional[str] = Field(default=None, max_length=34)
@@ -71,6 +72,7 @@ class PositionUpdate(BaseModel):
     shares: Optional[float] = Field(default=None, ge=0)
     cost_basis_chf: Optional[float] = Field(default=None, ge=0)
     current_price: Optional[float] = Field(default=None, ge=0)
+    count_as_cash: Optional[bool] = None
     manual_resistance: Optional[float] = Field(default=None, ge=0)
     stop_loss_price: Optional[float] = Field(default=None, ge=0)
     stop_loss_confirmed_at_broker: Optional[bool] = None
@@ -109,6 +111,7 @@ def _pos_to_dict(pos: Position) -> dict:
         "stop_loss_method": pos.stop_loss_method,
         "next_earnings_date": pos.next_earnings_date.isoformat() if pos.next_earnings_date else None,
         "is_etf": pos.is_etf,
+        "count_as_cash": pos.count_as_cash,
         "is_active": pos.is_active,
         "notes": decrypt_field(pos.notes),
         "bank_name": decrypt_field(pos.bank_name),

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -41,6 +41,7 @@ class PositionResponse(BaseModel):
     stop_loss_method: str | None = None
     next_earnings_date: str | None = None
     is_etf: bool
+    count_as_cash: bool = False
     is_active: bool
     notes: str | None = None
     bank_name: str | None = None

--- a/backend/models/position.py
+++ b/backend/models/position.py
@@ -100,6 +100,10 @@ class Position(Base):
     stop_loss_method: Mapped[str | None] = mapped_column(String(30))
     next_earnings_date: Mapped[datetime | None] = mapped_column(DateTime)
     is_etf: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Cash-Klassifikation fuer Geldmarkt-/T-Bill-ETFs: die Position bleibt eine
+    # echte, live-bepreiste Wertschrift (shares × price × fx, Performance laeuft
+    # normal), wird aber in Allokation/Cash-Quote/Snapshots als Cash gezaehlt.
+    count_as_cash: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"), default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     notes: Mapped[str | None] = mapped_column(Text)
     bank_name: Mapped[str | None] = mapped_column(Text)

--- a/backend/services/allocation_service.py
+++ b/backend/services/allocation_service.py
@@ -74,6 +74,10 @@ async def get_core_satellite_allocation(
             continue
         if pos.type.value not in TRADABLE_TYPES:
             continue
+        # Geldmarkt-/T-Bill-ETFs (count_as_cash) zaehlen als Cash, nicht als
+        # Aktien-Exposure — aus der Core/Satellite-Aufteilung ausnehmen.
+        if getattr(pos, "count_as_cash", False):
+            continue
 
         shares = float(pos.shares)
         price = float(pos.current_price) if pos.current_price else 0

--- a/backend/services/portfolio_service.py
+++ b/backend/services/portfolio_service.py
@@ -177,7 +177,10 @@ async def get_portfolio_summary(db: AsyncSession, user_id: uuid.UUID | None = No
         pnl = market_value_chf - invested
         pnl_pct = ((market_value_chf / invested) - 1) * 100 if invested > 0 else 0
 
-        type_key = pos.type.value
+        # Geldmarkt-/T-Bill-ETFs (count_as_cash) zaehlen in der Anlageklassen-
+        # Allokation als Cash, bleiben aber regulaer bepreist (Performance/PnL
+        # unveraendert).
+        type_key = "cash" if getattr(pos, "count_as_cash", False) else pos.type.value
         allocations_type[type_key] = allocations_type.get(type_key, 0) + market_value_chf
         style_key = pos.style.value if pos.style else "Nicht zugewiesen"
         allocations_style[style_key] = allocations_style.get(style_key, 0) + market_value_chf
@@ -231,6 +234,7 @@ async def get_portfolio_summary(db: AsyncSession, user_id: uuid.UUID | None = No
             "stop_loss_method": pos.stop_loss_method,
             "next_earnings_date": pos.next_earnings_date.isoformat() if pos.next_earnings_date else None,
             "is_etf": getattr(pos, 'is_etf', False) or pos.type == AssetType.etf,
+            "count_as_cash": getattr(pos, "count_as_cash", False),
             "is_multi_sector": is_multi_sector,
             "has_sector_weights": bool(etf_weights) if is_multi_sector else None,
             "is_stale": False,

--- a/backend/services/snapshot_service.py
+++ b/backend/services/snapshot_service.py
@@ -68,43 +68,44 @@ async def _calc_portfolio_value_fast(db: AsyncSession, user_id: uuid.UUID) -> tu
         if shares <= 0:
             continue
 
-        # Get price from cache (Redis/memory) or position.current_price
-        price = None
+        # Wertschriften-Bewertung in `pos_value` sammeln, dann einmalig zu
+        # total_value addieren. count_as_cash-Positionen (Geldmarkt-/T-Bill-ETFs)
+        # zaehlen zusaetzlich zu cash_value — als Cash klassifiziert, aber
+        # regulaer bepreist (kein Doppelzaehlen in total_value).
+        pos_value = None
         if pos.coingecko_id:
             cached = cache.get(f"crypto:{pos.coingecko_id}")
-            if cached:
-                price = cached.get("price")
+            if cached and cached.get("price"):
                 # Crypto prices from CoinGecko are already in CHF
-                if price:
-                    total_value += shares * price
-                    continue
+                pos_value = shares * cached["price"]
         elif pos.gold_org:
             # Zuerst spezifischen Metal-Key, dann Legacy-Gold-Key (für XAUCHF=X).
             cached = cache.get(f"metal_chf:{pos.ticker}") or (
                 cache.get("gold_chf") if pos.ticker == "XAUCHF=X" else None
             )
+            if cached and cached.get("price"):
+                pos_value = shares * cached["price"]
+
+        if pos_value is None:
+            ticker = pos.yfinance_ticker or pos.ticker
+            cached = cache.get(f"price:{ticker}")
             if cached:
                 price = cached.get("price")
-                if price:
-                    total_value += shares * price
-                    continue
-
-        ticker = pos.yfinance_ticker or pos.ticker
-        cached = cache.get(f"price:{ticker}")
-        if cached:
-            price = cached.get("price")
-        elif pos.current_price:
-            price = float(pos.current_price)
-
-        if price:
-            fx = _fx_or_none(pos.currency, fx_rates, pos.ticker)
-            if fx is None:
-                total_value += float(pos.cost_basis_chf or 0)
+            elif pos.current_price:
+                price = float(pos.current_price)
             else:
-                total_value += shares * price * fx
-        else:
-            # Fallback: use cost basis
-            total_value += float(pos.cost_basis_chf or 0)
+                price = None
+
+            if price:
+                fx = _fx_or_none(pos.currency, fx_rates, pos.ticker)
+                pos_value = float(pos.cost_basis_chf or 0) if fx is None else shares * price * fx
+            else:
+                # Fallback: use cost basis
+                pos_value = float(pos.cost_basis_chf or 0)
+
+        total_value += pos_value
+        if pos.count_as_cash:
+            cash_value += pos_value
 
     return total_value, cash_value
 
@@ -389,7 +390,7 @@ async def _record_user_bucket_snapshots(
             continue
         val = await _calc_position_value_chf(pos, fx_rates)
         totals[pos.bucket_id]["value"] += val
-        if pos.type in (AssetType.cash, AssetType.pension):
+        if pos.type in (AssetType.cash, AssetType.pension) or pos.count_as_cash:
             totals[pos.bucket_id]["cash"] += val
 
     # Cashflows pro Bucket fuer den Tag

--- a/backend/services/snapshot_service.py
+++ b/backend/services/snapshot_service.py
@@ -726,6 +726,10 @@ async def regenerate_snapshots(db: AsyncSession, user_id: uuid.UUID) -> dict:
         has_any_price = False
         bucket_value_today: dict = defaultdict(float)
         bucket_cash_today: dict = defaultdict(float)
+        # count_as_cash-Wertschriften (Geldmarkt-/T-Bill-ETF): ihr Marktwert
+        # zaehlt in total_value_chf (Wertschriften-Loop) UND als Cash — sonst
+        # weicht cash_chf nach dem Regen vom Daily-Recorder ab.
+        cash_securities_today = 0.0
 
         for pid, shares in current_holdings.items():
             if shares <= 0:
@@ -787,6 +791,14 @@ async def regenerate_snapshots(db: AsyncSession, user_id: uuid.UUID) -> dict:
                     bval = shares * per if per else cost_basis.get(pid, 0)
                 bucket_value_today[pos.bucket_id] += bval
 
+            # count_as_cash-ETF: Marktwert zusaetzlich als Cash fuehren (Portfolio
+            # + Bucket), spiegelt _calc_portfolio_value_fast/_record_user_bucket_
+            # snapshots. Keine Doppelzaehlung — val ist bereits in total_value_chf.
+            if pos.type == AssetType.etf and pos.count_as_cash:
+                cash_securities_today += val
+                if pos.bucket_id in eligible_bucket_ids:
+                    bucket_cash_today[pos.bucket_id] += (val if priced else bval)
+
         # Cash/Pension-Salden einrechnen (H8) — identisch zum Daily-Pfad,
         # der den manuellen Saldo (×FX bei Fremdwährung) in total UND cash_chf
         # führt. Vorher: cash_chf=0 → Sprung an der Regen→Daily-Grenze.
@@ -803,6 +815,9 @@ async def regenerate_snapshots(db: AsyncSession, user_id: uuid.UUID) -> dict:
                 bucket_value_today[cpos.bucket_id] += val
                 bucket_cash_today[cpos.bucket_id] += val
         total_value_chf += cash_chf_today
+        # count_as_cash-ETFs sind schon in total_value_chf (Wertschriften-Loop) —
+        # hier nur cash_chf erhoehen, nicht total.
+        cash_chf_today += cash_securities_today
 
         # Collect snapshot for weekdays (batch insert later)
         if current_date.weekday() < 5 and current_date >= first_date:

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,3 +1,3 @@
 # Single source of truth for backend version.
 # Keep in sync with frontend/package.json "version" field.
-APP_VERSION = "0.46.0"
+APP_VERSION = "0.47.0"

--- a/docs/EXTERNAL_API.md
+++ b/docs/EXTERNAL_API.md
@@ -325,6 +325,16 @@ Alle folgenden Endpoints erfordern Scope `write` und hinterlassen einen `ApiWrit
 > (siehe Tabelle oben). Jede Position im `/positions`-Response enthält die Felder
 > `bucket_id` (UUID oder `null`) und `risk_rules` (Position-Level-Override,
 > meistens `null`).
+>
+> **Cash-Klassifikation (v0.47):** `POST /positions` und
+> `PUT /positions/by-id/{id}` akzeptieren das optionale Feld
+> `count_as_cash` (boolean, Default `false`). Ist es `true`, bleibt die Position
+> eine regulaer bepreiste Wertschrift — Marktwert = `shares × Kurs × FX`,
+> Performance/PnL unveraendert —, wird aber in der Anlageklassen-Allokation
+> (`by_type` → `cash`), der Cash-Quote sowie den Portfolio- und Bucket-Snapshots
+> (`cash_chf`) als **Cash** gezaehlt und aus der Core/Satellite-Aufteilung
+> ausgenommen. Gedacht fuer Geldmarkt-/T-Bill-ETFs. Das Feld wird in jeder
+> Position des `/positions`- und `/portfolio/summary`-Response zurueckgegeben.
 
 ### EPS-Scanner (v0.44)
 
@@ -1104,6 +1114,7 @@ mit Token-ID, User-ID, Ticker und Order-ID protokolliert.
       "ma_status": "GESUND",
       "buy_date": "2023-08-15",
       "is_etf": false,
+      "count_as_cash": false,
       "stop_loss_price": 380.00,
       "stop_loss_method": "manual",
       "stop_loss_confirmed_at_broker": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openfolio",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AddPositionModal.jsx
+++ b/frontend/src/components/AddPositionModal.jsx
@@ -37,6 +37,7 @@ export default function AddPositionModal({ onClose, onSaved, allowedTypes = null
     label: '',
     iban: '',
     bucket_id: '',
+    count_as_cash: false,
   })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
@@ -116,6 +117,7 @@ export default function AddPositionModal({ onClose, onSaved, allowedTypes = null
         pricing_mode: isManualType ? 'manual' : 'auto',
         shares: isManualType ? 1 : Number(form.shares) || 0,
         current_price: isManualType ? Number(form.cost_basis_chf) || 0 : null,
+        count_as_cash: form.type === 'etf' ? !!form.count_as_cash : false,
         notes: form.notes || null,
         bank_name: form.bank_name?.trim() || null,
         iban: form.iban?.replace(/\s/g, '') || null,
@@ -265,6 +267,24 @@ export default function AddPositionModal({ onClose, onSaved, allowedTypes = null
                   </div>
                 )}
               </div>
+              {form.type === 'etf' && (
+                <div>
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={form.count_as_cash}
+                      onChange={(e) => set('count_as_cash', e.target.checked)}
+                      className="mt-0.5 rounded border-border text-primary focus:ring-primary/50"
+                    />
+                    <span className="text-sm text-text-secondary">
+                      Als Cash zählen (Geldmarkt-/T-Bill-ETF)
+                      <span className="block text-[11px] text-text-muted">
+                        Wird live bepreist, in der Allokation und Cash-Quote aber als Cash geführt.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              )}
               {showBucketSelector && (
                 <div>
                   <label htmlFor="add-gen-bucket" className="block text-xs text-text-secondary mb-1.5">Bucket</label>

--- a/frontend/src/components/EditPositionModal.jsx
+++ b/frontend/src/components/EditPositionModal.jsx
@@ -55,6 +55,7 @@ export default function EditPositionModal({ position, onClose, onSaved }) {
         current_price: position.current_price ?? '',
         shares: position.shares ?? 0,
         cost_basis_chf: position.cost_basis_chf ?? 0,
+        count_as_cash: position.count_as_cash || false,
         bank_name: position.bank_name || '',
         iban: position.iban || '',
       })
@@ -576,6 +577,24 @@ function StammdatenTab({ form, set, isMultiSector, sectorWeights, setSectorWeigh
       <Field id="edit-cost-basis" label="Einstandswert" className="col-span-1">
         <input id="edit-cost-basis" type="number" step="any" className={inputClass} value={form.cost_basis_chf} onChange={(e) => set('cost_basis_chf', e.target.value)} />
       </Field>
+      {form.type === 'etf' && (
+        <Field label="Cash-Klassifikation" className="col-span-2">
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.count_as_cash || false}
+              onChange={(e) => set('count_as_cash', e.target.checked)}
+              className="mt-0.5 rounded border-border text-primary focus:ring-primary/50"
+            />
+            <span className="text-sm text-text-secondary">
+              Als Cash zählen (Geldmarkt-/T-Bill-ETF)
+              <span className="block text-[11px] text-text-muted">
+                Wird live bepreist, in der Allokation und Cash-Quote aber als Cash geführt.
+              </span>
+            </span>
+          </label>
+        </Field>
+      )}
       <Field id="edit-pos-notes" label="Notizen" className="col-span-2">
         <textarea id="edit-pos-notes" className={inputClass + ' h-20 resize-none'} value={form.notes} onChange={(e) => set('notes', e.target.value)} />
       </Field>

--- a/frontend/src/components/PortfolioTable.jsx
+++ b/frontend/src/components/PortfolioTable.jsx
@@ -404,6 +404,9 @@ export default function PortfolioTable({ positions, onRefresh, totalFees = 0 }) 
                 <td className="p-3 text-text-primary whitespace-nowrap">
                   <span className="inline-flex items-center gap-1.5">
                     {p.name}
+                    {p.count_as_cash && (
+                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-text-muted/15 text-text-muted" title="Geldmarkt-/T-Bill-ETF — zählt als Cash">Cash</span>
+                    )}
                     <EarningsBadge date={p.next_earnings_date} />
                   </span>
                 </td>


### PR DESCRIPTION
## Was

Neues Flag `count_as_cash` pro Position. Eine ETF-Position mit `count_as_cash = true` bleibt eine **regulär bepreiste Wertschrift** (Marktwert = `Anteile × Kurs × FX`, Performance/PnL unverändert — HEILIGE Regel 1 unberührt), wird aber als **Cash** geführt:

- Anlageklassen-Allokation (`by_type` → `cash`)
- Cash-Quote sowie Portfolio- und Bucket-Snapshots (`cash_chf`), inkl. historischem Regen-Pfad
- aus der Core/Satellite-Aufteilung ausgenommen

**UI:** Checkbox „Als Cash zählen (Geldmarkt-/T-Bill-ETF)" im Add-/Edit-Dialog (nur bei Typ ETF) + „Cash"-Badge in der Portfolio-Tabelle.

**External API in Parität:** `count_as_cash` via `POST /positions` / `PUT /positions/by-id/{id}` (Scope `write`) setzbar und in jeder Position-Response enthalten. `docs/EXTERNAL_API.md` aktualisiert.

## Migration

`086_position_count_as_cash` — additives `ADD COLUMN count_as_cash boolean NOT NULL DEFAULT false`. Kein Backfill, kein Lock-Risiko, Downgrade vorhanden. Läuft automatisch via Entrypoint. Deploy-Anleitung: `HANDOVER-tbill-etf-cash-2026-06-25.md`.

## Qualität

- `@openfolio-audit`: **PASS, null Blocker.** Ein should-fix (Regen-Pfad cash_chf-Parität) und Nitpicks (ETF-Clamp serverseitig) sind in `d1a0e3a` adressiert.
- Backend-Tests: 1247 passed, 3 skipped. Frontend baut sauber.
- E2E gegen Dev-DB verifiziert (rolled back): cash-klassifizierter ETF wandert in `by_type:cash` und `cash_chf`, bleibt `type=etf` mit korrektem Marktwert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)