### PR TITLE
fix(allocation): count_as_cash-ETFs in Balkendiagrammen als Cash (v0.47.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Alle wichtigen Änderungen an OpenFolio werden in dieser Datei dokumentiert.
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/)
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
+## [0.47.1] — 2026-06-25
+
+### Behoben
+
+- **Allokations-Balkendiagramme: `count_as_cash`-ETFs jetzt konsistent als Cash.**
+  Die „Anlageklasse"-Balken kamen bereits korrekt vom Backend (`by_type` → cash),
+  aber der Hover-Tooltip und das client-seitig gerechnete Sektor-Chart
+  gruppierten weiter nach `position.type` — ein cash-markierter ETF erschien im
+  Tooltip unter „ETFs" und tauchte im Sektor-Chart unter seinem Aktien-Sektor auf.
+  Jetzt werden cash-klassifizierte ETFs im Typ-Tooltip unter „Cash" geführt und
+  aus dem Sektor-Chart ausgeschlossen (wie Cash/Pension). Die Währungsallokation
+  zählt sie weiterhin (echte FX-Exposure).
+
 ## [0.47.0] — 2026-06-25
 
 ### Hinzugefügt

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,3 +1,3 @@
 # Single source of truth for backend version.
 # Keep in sync with frontend/package.json "version" field.
-APP_VERSION = "0.47.0"
+APP_VERSION = "0.47.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openfolio",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.47.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AllocationCharts.jsx
+++ b/frontend/src/components/AllocationCharts.jsx
@@ -66,32 +66,37 @@ function buildTooltipMap(positions, realEstateEquity, etfSectorMap) {
 
   for (const p of positions) {
     if (p.shares <= 0) continue
-    const suffix = TYPE_SUFFIXES[p.type]
+    // count_as_cash-ETFs (Geldmarkt/T-Bill) zaehlen ueberall als Cash.
+    const isCashLike = !!p.count_as_cash
+    const suffix = isCashLike ? 'Cash' : TYPE_SUFFIXES[p.type]
     const item = suffix
       ? { ...p, _displayName: `${p.name} (${suffix})` }
       : p
 
     // By type
-    const typeKey = p.type || 'stock'
+    const typeKey = isCashLike ? 'cash' : (p.type || 'stock')
     addTo('type', typeKey, item)
 
-    // By sector: Multi-Sector positions with weights get distributed
-    const isMultiSector = p.is_multi_sector
-    const etfWeights = isMultiSector ? etfSectorMap?.[p.ticker] : null
-    if (isMultiSector && etfWeights?.length) {
-      for (const sw of etfWeights) {
-        const sectorValue = p.market_value_chf * sw.weight_pct / 100
-        addTo('sector', sw.sector, { ...item, market_value_chf: sectorValue, _displayName: `${p.ticker} (${sw.weight_pct}%)` })
+    // By sector: cash-klassifizierte Positionen werden (wie Cash/Pension) aus
+    // dem Sektor-Chart ausgeschlossen. Waehrung laeuft weiter (echte FX-Exposure).
+    if (!isCashLike) {
+      const isMultiSector = p.is_multi_sector
+      const etfWeights = isMultiSector ? etfSectorMap?.[p.ticker] : null
+      if (isMultiSector && etfWeights?.length) {
+        for (const sw of etfWeights) {
+          const sectorValue = p.market_value_chf * sw.weight_pct / 100
+          addTo('sector', sw.sector, { ...item, market_value_chf: sectorValue, _displayName: `${p.ticker} (${sw.weight_pct}%)` })
+        }
+      } else if (isMultiSector) {
+        addTo('sector', 'Multi-Sector (unverteilt)', item)
+      } else if (p.sector && !EXCLUDED_SECTORS.has(p.sector)) {
+        addTo('sector', p.sector, item)
+      } else if (TYPE_TO_SECTOR[p.type]) {
+        // Crypto/Commodity get their own sector category
+        addTo('sector', TYPE_TO_SECTOR[p.type], item)
       }
-    } else if (isMultiSector) {
-      addTo('sector', 'Multi-Sector (unverteilt)', item)
-    } else if (p.sector && !EXCLUDED_SECTORS.has(p.sector)) {
-      addTo('sector', p.sector, item)
-    } else if (TYPE_TO_SECTOR[p.type]) {
-      // Crypto/Commodity get their own sector category
-      addTo('sector', TYPE_TO_SECTOR[p.type], item)
+      // Cash and Pension are excluded from sector chart (shown in Anlageklasse)
     }
-    // Cash and Pension are excluded from sector chart (shown in Anlageklasse)
 
     // By currency
     if (p.currency) {
@@ -215,7 +220,7 @@ function filterSectors(data, positions, etfSectorMap) {
   const buckets = {}
   for (const p of positions) {
     if (p.shares <= 0) continue
-    if (SECTOR_EXCLUDED_TYPES.has(p.type)) continue
+    if (SECTOR_EXCLUDED_TYPES.has(p.type) || p.count_as_cash) continue
 
     const val = p.market_value_chf || 0
     const cat = TYPE_TO_SECTOR[p.type]


### PR DESCRIPTION
## Problem

Nach dem Markieren eines ETFs als `count_as_cash` (v0.47.0) erschien dieser in den Allokations-**Balkendiagrammen** nicht durchgängig als Cash.

## Ursache

Die „Anlageklasse"-Balken kamen bereits korrekt vom Backend (`by_type` → `cash`). Aber zwei Stellen im Frontend rechnen **client-seitig aus `position.type`** und ignorierten das Flag:
- `buildTooltipMap` — der Hover-Tooltip gruppierte nach `p.type` → ETF erschien unter „ETFs", nicht „Cash".
- `filterSectors` — das Sektor-Chart wird client-seitig neu gerechnet und schloss nur `cash`/`pension` aus → cash-markierter ETF tauchte unter seinem Aktien-Sektor auf.

## Fix (frontend-only)

- Typ-Tooltip: `count_as_cash` → „Cash" (mit „(Cash)"-Suffix).
- Sektor-Chart + Tooltip: `count_as_cash` ausgeschlossen (wie Cash/Pension).
- Währungsallokation unverändert — ein USD-T-Bill-ETF hat echte FX-Exposure.

Tabellen-Gruppierung bewusst unverändert: der ETF bleibt als echte Position (Anteile/Kurs/Performance + „Cash"-Badge) in der Holdings-Tabelle.

Frontend baut sauber. Reiner Display-Fix, kein Backend-/Migrations-Change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)