### PR TITLE
refactor(portfolio): toten count_as_cash-Badge aus Aktien-Tabelle entfernen

### DIFF
--- a/frontend/src/components/PortfolioTable.jsx
+++ b/frontend/src/components/PortfolioTable.jsx
@@ -404,9 +404,6 @@ export default function PortfolioTable({ positions, onRefresh, totalFees = 0 }) 
                 <td className="p-3 text-text-primary whitespace-nowrap">
                   <span className="inline-flex items-center gap-1.5">
                     {p.name}
-                    {p.count_as_cash && (
-                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-text-muted/15 text-text-muted" title="Geldmarkt-/T-Bill-ETF — zählt als Cash">Cash</span>
-                    )}
                     <EarningsBadge date={p.next_earnings_date} />
                   </span>
                 </td>


### PR DESCRIPTION
## Cleanup

Seit v0.47.5 schliesst `stockPositions` `count_as_cash` aus — Geldmarkt-/T-Bill-ETFs laufen im Liquiditäts-Widget. `PortfolioTable` wird ausschliesslich mit `stockPositions` gerendert (verifiziert: einziger Consumer, `Portfolio.jsx:198`), also ist der `count_as_cash`-Cash-Badge-Branch in `PortfolioTable.jsx` toter, unerreichbarer Code.

Entfernt (4 Zeilen). **Kein funktionaler Effekt.** Einzige `count_as_cash`-Referenz in der Datei, Frontend-Build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
